### PR TITLE
refactor(framework): fix breaking changes with terraform plugin framework v.0.10.0

### DIFF
--- a/internal/provider/resource_jira_issue_screen.go
+++ b/internal/provider/resource_jira_issue_screen.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_validation"
 )
@@ -77,7 +77,7 @@ func (jiraIssueScreenResourceType) NewResource(ctx context.Context, in tfsdk.Pro
 }
 
 func (jiraIssueScreenResource) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
-	tfsdk.ResourceImportStatePassthroughID(ctx, tftypes.NewAttributePath().WithAttributeName("id"), req, resp)
+	tfsdk.ResourceImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
 func (r jiraIssueScreenResource) Create(ctx context.Context, req tfsdk.CreateResourceRequest, resp *tfsdk.CreateResourceResponse) {

--- a/internal/provider/resource_jira_issue_type.go
+++ b/internal/provider/resource_jira_issue_type.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	"github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_validation"
 
@@ -99,7 +99,7 @@ func (t jiraIssueTypeResourceType) NewResource(ctx context.Context, in tfsdk.Pro
 }
 
 func (r jiraIssueTypeResource) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
-	tfsdk.ResourceImportStatePassthroughID(ctx, tftypes.NewAttributePath().WithAttributeName("id"), req, resp)
+	tfsdk.ResourceImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
 func (r jiraIssueTypeResource) Create(ctx context.Context, req tfsdk.CreateResourceRequest, resp *tfsdk.CreateResourceResponse) {

--- a/internal/provider/resource_jira_issue_type_scheme.go
+++ b/internal/provider/resource_jira_issue_type_scheme.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_validation"
@@ -85,7 +85,7 @@ func (t jiraIssueTypeSchemeResourceType) NewResource(ctx context.Context, in tfs
 }
 
 func (r jiraIssueTypeSchemeResource) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
-	tfsdk.ResourceImportStatePassthroughID(ctx, tftypes.NewAttributePath().WithAttributeName("id"), req, resp)
+	tfsdk.ResourceImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
 func (r jiraIssueTypeSchemeResource) Create(ctx context.Context, req tfsdk.CreateResourceRequest, resp *tfsdk.CreateResourceResponse) {


### PR DESCRIPTION
Relates https://github.com/openscientia/terraform-provider-atlassian/pull/21.
Relates https://github.com/hashicorp/terraform-plugin-framework/pull/390.
Closes #22 

```
make testacc
TF_ACC=1 go test -v -cover -timeout 120m ./...
?   	github.com/openscientia/terraform-provider-atlassian	[no test files]
=== RUN   TestAccJiraIssueTypeSchemeDataSource
--- PASS: TestAccJiraIssueTypeSchemeDataSource (3.63s)
=== RUN   TestAccJiraIssueTypeDataSource
--- PASS: TestAccJiraIssueTypeDataSource (0.98s)
=== RUN   TestAccJiraIssueScreen
--- PASS: TestAccJiraIssueScreen (1.86s)
=== RUN   TestAccJiraIssueTypeSchemeResource
--- PASS: TestAccJiraIssueTypeSchemeResource (3.46s)
=== RUN   TestAccJiraIssueTypeResource
--- PASS: TestAccJiraIssueTypeResource (2.32s)
PASS
coverage: 66.8% of statements
ok  	github.com/openscientia/terraform-provider-atlassian/internal/provider	(cached)	coverage: 66.8% of statements
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_plan_modification	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_validation	[no test files]
```
