### PR TITLE
Add `url` attribute validation in provider configuration

### DIFF
--- a/.changelog/42.txt
+++ b/.changelog/42.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+provider: Add `url` attribute validation.
+```

--- a/internal/provider/attribute_validation/attribute_validators.go
+++ b/internal/provider/attribute_validation/attribute_validators.go
@@ -8,6 +8,57 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+type intValuesValidator struct {
+	Values []int
+}
+
+func (v intValuesValidator) Description(ctx context.Context) string {
+	return fmt.Sprintf("only valid int values are %v", v.Values)
+}
+
+func (v intValuesValidator) MarkdownDescription(ctx context.Context) string {
+	return fmt.Sprintf("only valid int values are %v", v.Values)
+}
+
+func (v intValuesValidator) Validate(ctx context.Context, req tfsdk.ValidateAttributeRequest, resp *tfsdk.ValidateAttributeResponse) {
+
+	var num types.Int64
+	diags := tfsdk.ValueAs(ctx, req.AttributeConfig, &num)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+
+	if num.Unknown || num.Null {
+		return
+	}
+
+	flag := false
+	for _, s := range v.Values {
+		if num.Value == int64(s) {
+			flag = true
+		}
+	}
+
+	if !flag {
+		resp.Diagnostics.AddAttributeError(
+			req.AttributePath,
+			"Invalid Value",
+			fmt.Sprintf("only valid int values are %v", v.Values),
+		)
+
+		return
+	}
+}
+
+func IntValues(values []int) intValuesValidator {
+	return intValuesValidator{
+		Values: values,
+	}
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 type stringLengthBetweenValidator struct {
 	Min int
 	Max int
@@ -111,53 +162,4 @@ func StringValues(values []string) stringValuesValidator {
 	}
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-type intValuesValidator struct {
-	Values []int
-}
-
-func (v intValuesValidator) Description(ctx context.Context) string {
-	return fmt.Sprintf("only valid int values are %v", v.Values)
-}
-
-func (v intValuesValidator) MarkdownDescription(ctx context.Context) string {
-	return fmt.Sprintf("only valid int values are %v", v.Values)
-}
-
-func (v intValuesValidator) Validate(ctx context.Context, req tfsdk.ValidateAttributeRequest, resp *tfsdk.ValidateAttributeResponse) {
-
-	var num types.Int64
-	diags := tfsdk.ValueAs(ctx, req.AttributeConfig, &num)
-	resp.Diagnostics.Append(diags...)
-	if diags.HasError() {
-		return
-	}
-
-	if num.Unknown || num.Null {
-		return
-	}
-
-	flag := false
-	for _, s := range v.Values {
-		if num.Value == int64(s) {
-			flag = true
-		}
-	}
-
-	if !flag {
-		resp.Diagnostics.AddAttributeError(
-			req.AttributePath,
-			"Invalid Value",
-			fmt.Sprintf("only valid int values are %v", v.Values),
-		)
-
-		return
-	}
-}
-
-func IntValues(values []int) intValuesValidator {
-	return intValuesValidator{
-		Values: values,
-	}
-}
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	jira "github.com/ctreminiom/go-atlassian/jira/v3"
+	"github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_validation"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -32,6 +33,9 @@ func (p *provider) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostic
 				Computed:            true,
 				Optional:            true,
 				Type:                types.StringType,
+				Validators: []tfsdk.AttributeValidator{
+					attribute_validation.UrlWithScheme("https"),
+				},
 			},
 			"username": {
 				MarkdownDescription: "Atlassian Username. Can also be set with the `ATLASSIAN_USERNAME` environment variable.",

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -2,10 +2,12 @@ package atlassian
 
 import (
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 // testAccProtoV6ProviderFactories are used to instantiate a provider during
@@ -17,10 +19,6 @@ var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServe
 }
 
 func testAccPreCheck(t *testing.T) {
-	// You can add code here to run prior to any test case execution, for example assertions
-	// about the appropriate environment variables being set are common to see in a pre-check
-	// function.
-
 	if v := os.Getenv("ATLASSIAN_USERNAME"); v == "" {
 		t.Fatal("ATLASSIAN_USERNAME must be set to run acceptance tests.")
 	}
@@ -32,4 +30,49 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("ATLASSIAN_URL"); v == "" {
 		t.Error("ATLASSIAN_URL must be set to run acceptance tests.")
 	}
+}
+
+func TestProvider_InvalidUrlAttribute(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					provider "atlassian" {
+						url = " https://test.atlassian.net"
+					}
+
+					resource "atlassian_jira_issue_type" "test" {
+						name = "test"
+					}
+				`,
+				ExpectError: regexp.MustCompile(`Parsing URL\s.*\sfailed`),
+			},
+			{
+				Config: `
+					provider "atlassian" {
+						url = "test.atlassian.net"
+					}
+
+					resource "atlassian_jira_issue_type" "test" {
+						name = "test"
+					}
+				`,
+				ExpectError: regexp.MustCompile(`contains no host`),
+			},
+			{
+				Config: `
+					provider "atlassian" {
+						url = "http://test.atlassian.net"
+					}
+
+					resource "atlassian_jira_issue_type" "test" {
+						name = "test"
+					}
+				`,
+				ExpectError: regexp.MustCompile(`expected to use scheme from`),
+			},
+		},
+	})
 }


### PR DESCRIPTION
```
go test -v -cover -timeout 120m ./... -run TestProvider
?   	github.com/openscientia/terraform-provider-atlassian	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/issuelabels	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/prlabels	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/repolabels	[no test files]
=== RUN   TestProvider_InvalidUrlAttribute
--- PASS: TestProvider_InvalidUrlAttribute (0.14s)
PASS
coverage: 2.4% of statements
ok  	github.com/openscientia/terraform-provider-atlassian/internal/provider	0.477s	coverage: 2.4% of statements
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_plan_modification	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_validation	[no test files]
```
Closes #42 