### PR TITLE
feat(new-resource): `atlassian_jira_issue_field_configuration_item`

### DIFF
--- a/.changelog/73.txt
+++ b/.changelog/73.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+atlassian_jira_issue_field_configuration_item
+```

--- a/docs/resources/jira_issue_field_configuration_item.md
+++ b/docs/resources/jira_issue_field_configuration_item.md
@@ -1,0 +1,151 @@
+---
+page_title: "Atlassian Cloud: atlassian_jira_issue_field_configuration_item"
+subcategory: "Jira Cloud"
+description: |-
+  Manages atlassian_jira_issue_field_configuration_item.
+---
+
+# Resource: atlassian_jira_issue_field_configuration_item
+
+Provides an `atlassian_jira_issue_field_configuration_item` resource.
+
+Learn more about [Jira Issue Field Configuration Items](https://support.atlassian.com/jira-cloud-administration/docs/change-a-field-configuration/).
+
+See more details about the [Jira Cloud Platform REST API for Issue Field Configuration Items](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-field-configurations/#api-rest-api-3-fieldconfiguration-id-fields-get).
+
+~> **Note** `terraform destroy` does not delete `atlassian_jira_issue_field_configuration_item` but does remove the resource from Terraform state.
+
+-> **Note** `atlassian_jira_issue_field_configuration_item` can only reference [`atlassian_jira_issue_field_configuration`](https://registry.terraform.io/providers/openscientia/atlassian/latest/docs/resources/jira_issue_field_configuration) used in [company-managed (classic) projects](https://support.atlassian.com/jira-software-cloud/docs/what-are-team-managed-and-company-managed-projects/).
+
+## Example Usage
+
+### Basic
+
+```terraform
+resource "atlassian_jira_issue_field_configuration" "example" {
+  name = "foo"
+}
+
+resource "atlassian_jira_issue_field_configuration_item" "example" {
+  issue_field_configuration = atlassian_jira_issue_field_configuration.example.id
+  item = {
+    id = "customfield_10000"
+  }
+}
+```
+
+### Hide or Show fields
+
+-> **Note** `item.is_hidden` can be set to `true` to ensure that the field does not appear on any `atlassian_jira_issue_screen` (i.e. issue operation screens, workflow transition screens) where a specific `atlassian_jira_issue_field_configuration` applies. See more [details](https://support.atlassian.com/jira-cloud-administration/docs/specify-field-behavior/#Hide-or-show-a-field).
+
+~> **Note** Hiding a field in the `atlassian_jira_issue_field_configuration_item` resource is distinct from not adding a field to a `atlassian_jira_issue_screen`. Fields hidden through the `atlassian_jira_issue_field_configuration_item` resource will be hidden in all applicable screens, regardless of whether or not they have been added to any `atlassian_jira_issue_screen`.
+
+```terraform
+resource "atlassian_jira_issue_field_configuration" "example" {
+  name = "foo"
+}
+
+resource "atlassian_jira_issue_field_configuration_item" "example_hide" {
+  issue_field_configuration = atlassian_jira_issue_field_configuration.example.id
+  item = {
+    id        = "customfield_10000"
+    is_hidden = true
+  }
+}
+
+resource "atlassian_jira_issue_field_configuration_item" "example_show" {
+  issue_field_configuration = atlassian_jira_issue_field_configuration.example.id
+  item = {
+    id        = "customfield_10001"
+    is_hidden = false
+  }
+}
+```
+
+### Required or Optional fields
+
+-> **Note** `item.is_required` can be set to `true` to ensures that Jira validates the field has been given a value whenever an issue is edited. Alternatively, set to `false` to make a field optional if no value is required. See more [details](https://support.atlassian.com/jira-cloud-administration/docs/specify-field-behavior/#Make-a-field-required-or-optional).
+
+~> **Note** If you make a field required, ensure that the field is present on all Create Issue `atlassian_jira_issue_screen` resources associated to different `atlassian_jira_issue_type` or projects.
+
+```terraform
+resource "atlassian_jira_issue_field_configuration" "example" {
+  name = "foo"
+}
+
+resource "atlassian_jira_issue_field_configuration_item" "example_required" {
+  issue_field_configuration = atlassian_jira_issue_field_configuration.example.id
+  item = {
+    id          = "customfield_10000"
+    is_required = true
+  }
+}
+
+resource "atlassian_jira_issue_field_configuration_item" "example_optional" {
+  issue_field_configuration = atlassian_jira_issue_field_configuration.example.id
+  item = {
+    id          = "customfield_10001"
+    is_required = false
+  }
+}
+```
+
+### Renderers
+
+-> **Note** `item.renderer` can be set for text fields to the default text renderer ([`text-renderer`](https://support.atlassian.com/jira-cloud-administration/docs/configure-renderers/#Default-text-renderer)) or wiki style renderer ([`wiki-renderer`](https://support.atlassian.com/jira-cloud-administration/docs/configure-renderers/#Wiki-style-renderer)). However, `item.renderer` cannot be set for multi-select fields using the [autocomplete renderer](https://support.atlassian.com/jira-cloud-administration/docs/configure-renderers/#Autocomplete-and-select-list-renderers) or [select list renderer](https://support.atlassian.com/jira-cloud-administration/docs/configure-renderers/#Autocomplete-and-select-list-renderers). See more [details](https://support.atlassian.com/jira-cloud-administration/docs/configure-renderers/).
+
+```terraform
+resource "atlassian_jira_issue_field_configuration" "example" {
+  name = "foo"
+}
+
+resource "atlassian_jira_issue_field_configuration_item" "example_text_renderer" {
+  issue_field_configuration = atlassian_jira_issue_field_configuration.example.id
+  item = {
+    id       = "customfield_10000"
+    renderer = "text-renderer"
+  }
+}
+
+resource "atlassian_jira_issue_field_configuration_item" "example_wiki_renderer" {
+  issue_field_configuration = atlassian_jira_issue_field_configuration.example.id
+  item = {
+    id       = "customfield_10001"
+    renderer = "wiki-renderer"
+  }
+}
+```
+
+<!-- schema generated by tfplugindocs -->
+## Schema
+
+### Required
+
+- `issue_field_configuration` (String) (Forces new resource) The ID of the issue field configuration.
+- `item` (Attributes) Details of a field within the issue field configuration. (see [below for nested schema](#nestedatt--item))
+
+### Read-Only
+
+- `id` (String) The ID of the issue field configuration item. It is computed using `issue_field_configuration` and `item.id` separated by a hyphen (`-`).
+
+<a id="nestedatt--item"></a>
+### Nested Schema for `item`
+
+Required:
+
+- `id` (String) (Forces new resource) The ID of the field within the issue field configuration.
+
+Optional:
+
+- `description` (String) The description of the field within the issue field configuration.
+- `is_hidden` (Boolean) Whether the field is hidden in the issue field configuration. Can be `true` or `false`.
+- `is_required` (Boolean) Whether the field is required in the issue field configuration. Can be `true` or `false`.
+- `renderer` (String) The renderer type for the field within the issue field configuration. Can be `text-renderer` or `wiki-renderer`.
+
+## Import
+
+`atlassian_jira_issue_field_configuration_item` can be imported using the `issue_field_configuration` and `item.id` separated by a comma (`,`) e.g.,
+
+```sh
+$ terraform import atlassian_jira_issue_field_configuration_item.foo 10000,customfield_10000
+```

--- a/examples/resources/atlassian_jira_issue_field_configuration_item/basic.tf
+++ b/examples/resources/atlassian_jira_issue_field_configuration_item/basic.tf
@@ -1,0 +1,10 @@
+resource "atlassian_jira_issue_field_configuration" "example" {
+  name = "foo"
+}
+
+resource "atlassian_jira_issue_field_configuration_item" "example" {
+  issue_field_configuration = atlassian_jira_issue_field_configuration.example.id
+  item = {
+    id = "customfield_10000"
+  }
+}

--- a/examples/resources/atlassian_jira_issue_field_configuration_item/ishidden.tf
+++ b/examples/resources/atlassian_jira_issue_field_configuration_item/ishidden.tf
@@ -1,0 +1,19 @@
+resource "atlassian_jira_issue_field_configuration" "example" {
+  name = "foo"
+}
+
+resource "atlassian_jira_issue_field_configuration_item" "example_hide" {
+  issue_field_configuration = atlassian_jira_issue_field_configuration.example.id
+  item = {
+    id        = "customfield_10000"
+    is_hidden = true
+  }
+}
+
+resource "atlassian_jira_issue_field_configuration_item" "example_show" {
+  issue_field_configuration = atlassian_jira_issue_field_configuration.example.id
+  item = {
+    id        = "customfield_10001"
+    is_hidden = false
+  }
+}

--- a/examples/resources/atlassian_jira_issue_field_configuration_item/isrequired.tf
+++ b/examples/resources/atlassian_jira_issue_field_configuration_item/isrequired.tf
@@ -1,0 +1,20 @@
+resource "atlassian_jira_issue_field_configuration" "example" {
+  name = "foo"
+}
+
+resource "atlassian_jira_issue_field_configuration_item" "example_required" {
+  issue_field_configuration = atlassian_jira_issue_field_configuration.example.id
+  item = {
+    id          = "customfield_10000"
+    is_required = true
+  }
+}
+
+resource "atlassian_jira_issue_field_configuration_item" "example_optional" {
+  issue_field_configuration = atlassian_jira_issue_field_configuration.example.id
+  item = {
+    id          = "customfield_10001"
+    is_required = false
+  }
+}
+

--- a/examples/resources/atlassian_jira_issue_field_configuration_item/renderers.tf
+++ b/examples/resources/atlassian_jira_issue_field_configuration_item/renderers.tf
@@ -1,0 +1,19 @@
+resource "atlassian_jira_issue_field_configuration" "example" {
+  name = "foo"
+}
+
+resource "atlassian_jira_issue_field_configuration_item" "example_text_renderer" {
+  issue_field_configuration = atlassian_jira_issue_field_configuration.example.id
+  item = {
+    id       = "customfield_10000"
+    renderer = "text-renderer"
+  }
+}
+
+resource "atlassian_jira_issue_field_configuration_item" "example_wiki_renderer" {
+  issue_field_configuration = atlassian_jira_issue_field_configuration.example.id
+  item = {
+    id       = "customfield_10001"
+    renderer = "wiki-renderer"
+  }
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -160,12 +160,13 @@ func (p *provider) Configure(ctx context.Context, req tfsdk.ConfigureProviderReq
 
 func (p *provider) GetResources(ctx context.Context) (map[string]tfsdk.ResourceType, diag.Diagnostics) {
 	return map[string]tfsdk.ResourceType{
-		"atlassian_jira_issue_field_configuration": &jiraIssueFieldConfigurationResourceType{},
-		"atlassian_jira_issue_screen":              jiraIssueScreenResourceType{},
-		"atlassian_jira_issue_type":                jiraIssueTypeResourceType{},
-		"atlassian_jira_issue_type_scheme":         jiraIssueTypeSchemeResourceType{},
-		"atlassian_jira_issue_type_screen_scheme":  &jiraIssueTypeScreenSchemeResourceType{},
-		"atlassian_jira_screen_scheme":             &jiraScreenSchemeResourceType{},
+		"atlassian_jira_issue_field_configuration_item": &jiraIssueFieldConfigurationItemResourceType{},
+		"atlassian_jira_issue_field_configuration":      &jiraIssueFieldConfigurationResourceType{},
+		"atlassian_jira_issue_screen":                   jiraIssueScreenResourceType{},
+		"atlassian_jira_issue_type":                     jiraIssueTypeResourceType{},
+		"atlassian_jira_issue_type_scheme":              jiraIssueTypeSchemeResourceType{},
+		"atlassian_jira_issue_type_screen_scheme":       &jiraIssueTypeScreenSchemeResourceType{},
+		"atlassian_jira_screen_scheme":                  &jiraScreenSchemeResourceType{},
 	}, nil
 }
 

--- a/internal/provider/resource_jira_issue_field_configuration_item.go
+++ b/internal/provider/resource_jira_issue_field_configuration_item.go
@@ -1,0 +1,381 @@
+package atlassian
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/ctreminiom/go-atlassian/pkg/infra/models"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+type (
+	jiraIssueFieldConfigurationItemResource struct {
+		p provider
+	}
+
+	jiraIssueFieldConfigurationItemResourceType struct{}
+
+	jiraIssueFieldConfigurationItemResourceModel struct {
+		ID                      types.String                     `tfsdk:"id"`
+		IssueFieldConfiguration types.String                     `tfsdk:"issue_field_configuration"`
+		Item                    *jiraIssueFieldConfigurationItem `tfsdk:"item"`
+	}
+
+	jiraIssueFieldConfigurationItem struct {
+		ID          types.String `tfsdk:"id"`
+		Description types.String `tfsdk:"description"`
+		IsHidden    types.Bool   `tfsdk:"is_hidden"`
+		IsRequired  types.Bool   `tfsdk:"is_required"`
+		Renderer    types.String `tfsdk:"renderer"`
+	}
+)
+
+var (
+	_                   tfsdk.Resource                = (*jiraIssueFieldConfigurationItemResource)(nil)
+	_                   tfsdk.ResourceType            = (*jiraIssueFieldConfigurationItemResourceType)(nil)
+	_                   tfsdk.ResourceWithImportState = (*jiraIssueFieldConfigurationItemResource)(nil)
+	renderableItemTypes                               = []string{"string", "comments-page"}
+)
+
+func (*jiraIssueFieldConfigurationItemResourceType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
+	return tfsdk.Schema{
+		Version:             1,
+		MarkdownDescription: "Jira Issue Field Configuration Item Resource",
+		Attributes: map[string]tfsdk.Attribute{
+			"id": {
+				MarkdownDescription: "The ID of the issue field configuration item. " +
+					"It is computed using `issue_field_configuration` and `item.id` separated by a hyphen (`-`).",
+				Computed: true,
+				Type:     types.StringType,
+			},
+			"issue_field_configuration": {
+				MarkdownDescription: "(Forces new resource) The ID of the issue field configuration.",
+				Required:            true,
+				Type:                types.StringType,
+				PlanModifiers: tfsdk.AttributePlanModifiers{
+					tfsdk.RequiresReplace(),
+				},
+			},
+			"item": {
+				MarkdownDescription: "Details of a field within the issue field configuration.",
+				Required:            true,
+				Attributes: tfsdk.SingleNestedAttributes(
+					map[string]tfsdk.Attribute{
+						"id": {
+							MarkdownDescription: "(Forces new resource) The ID of the field within the issue field configuration.",
+							Required:            true,
+							Type:                types.StringType,
+							Validators: []tfsdk.AttributeValidator{
+								stringvalidator.RegexMatches(regexp.MustCompile(`^customfield_[0-9]{5}$|^[a-zA-Z]*$`), ""),
+							},
+							PlanModifiers: tfsdk.AttributePlanModifiers{
+								tfsdk.RequiresReplace(),
+							},
+						},
+						"description": {
+							MarkdownDescription: "The description of the field within the issue field configuration.",
+							Computed:            true,
+							Optional:            true,
+							Type:                types.StringType,
+						},
+						"is_hidden": {
+							MarkdownDescription: "Whether the field is hidden in the issue field configuration. " +
+								"Can be `true` or `false`.",
+							Computed: true,
+							Optional: true,
+							Type:     types.BoolType,
+						},
+						"is_required": {
+							MarkdownDescription: "Whether the field is required in the issue field configuration. " +
+								"Can be `true` or `false`.",
+							Computed: true,
+							Optional: true,
+							Type:     types.BoolType,
+						},
+						"renderer": {
+							MarkdownDescription: "The renderer type for the field within the issue field configuration. " +
+								"Can be `text-renderer` or `wiki-renderer`.",
+							Computed: true,
+							Optional: true,
+							Type:     types.StringType,
+							Validators: []tfsdk.AttributeValidator{
+								stringvalidator.OneOf("text-renderer", "wiki-renderer"),
+							},
+						},
+					},
+				),
+			},
+		},
+	}, nil
+}
+
+func (r *jiraIssueFieldConfigurationItemResourceType) NewResource(ctx context.Context, in tfsdk.Provider) (tfsdk.Resource, diag.Diagnostics) {
+	provider, diags := convertProviderType(in)
+
+	return &jiraIssueFieldConfigurationItemResource{
+		p: provider,
+	}, diags
+}
+
+func (r *jiraIssueFieldConfigurationItemResource) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
+	idParts := strings.Split(req.ID, ",")
+	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+		resp.Diagnostics.AddError("Unexpected Import Identifier",
+			fmt.Sprintf("Expected import identifier with format: issue_field_configuration, item.id. Got: %q", req.ID))
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("issue_field_configuration"), idParts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("item").AtName("id"), idParts[1])...)
+}
+
+func (r *jiraIssueFieldConfigurationItemResource) Create(ctx context.Context, req tfsdk.CreateResourceRequest, resp *tfsdk.CreateResourceResponse) {
+	tflog.Debug(ctx, "Creating issue field configuration item")
+
+	if !r.p.configured {
+		resp.Diagnostics.AddError(
+			"Provider not configured",
+			"The provider hasn't been configured before apply, likely because it depends on an unknown value from another resource. This leads to weird stuff happening, so we'd prefer if you didn't do that. Thanks!",
+		)
+	}
+
+	var plan jiraIssueFieldConfigurationItemResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	tflog.Debug(ctx, "Loaded issue field configuration item plan", map[string]interface{}{
+		"issueFieldConfigurationItem": fmt.Sprintf("%+v, %+v", plan, *plan.Item),
+	})
+
+	if !plan.Item.Renderer.IsNull() && !plan.Item.Renderer.IsUnknown() {
+		err := r.checkIssueFieldConfigurationItemRenderable(ctx, &plan)
+		if err != nil {
+			resp.Diagnostics.AddError("Client Error", err.Error())
+			return
+		}
+	}
+
+	issueFieldConfigurationId, _ := strconv.Atoi(plan.IssueFieldConfiguration.Value)
+	createRequestPayload := models.UpdateFieldConfigurationItemPayloadScheme{
+		FieldConfigurationItems: []*models.FieldConfigurationItemScheme{
+			{
+				ID:          plan.Item.ID.Value,
+				IsHidden:    plan.Item.IsHidden.Value,
+				IsRequired:  plan.Item.IsRequired.Value,
+				Description: plan.Item.Description.Value,
+				Renderer:    plan.Item.Renderer.Value,
+			},
+		},
+	}
+
+	res, err := r.p.jira.Issue.Field.Configuration.Item.Update(ctx, issueFieldConfigurationId, &createRequestPayload)
+	if err != nil {
+		var resBody string
+		if res != nil {
+			resBody = res.Bytes.String()
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create issue field configuration item, got error: %s\n%s", err, resBody))
+		return
+	}
+
+	items, res, err := r.p.jira.Issue.Field.Configuration.Item.Gets(ctx, issueFieldConfigurationId, 0, 50)
+	if err != nil {
+		var resBody string
+		if res != nil {
+			resBody = res.Bytes.String()
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get issue field configuration items, got error: %s\n%s", err, resBody))
+		return
+	}
+
+	for _, i := range items.Values {
+		if i.ID == plan.Item.ID.Value {
+			plan.Item = &jiraIssueFieldConfigurationItem{
+				ID:          types.String{Value: plan.Item.ID.Value},
+				Description: types.String{Value: i.Description},
+				IsHidden:    types.Bool{Value: i.IsHidden},
+				IsRequired:  types.Bool{Value: i.IsRequired},
+				Renderer:    types.String{Value: i.Renderer},
+			}
+		}
+	}
+	tflog.Debug(ctx, "Created issue field configuration item")
+
+	plan.ID = types.String{Value: createIssueFieldConfigurationItemID(plan.IssueFieldConfiguration.Value, plan.Item.ID.Value)}
+
+	tflog.Debug(ctx, "Storing issue field configuration item info into the state", map[string]interface{}{
+		"issueFieldConfigurationItem": fmt.Sprintf("%+v, %+v", plan, *plan.Item),
+	})
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *jiraIssueFieldConfigurationItemResource) Read(ctx context.Context, req tfsdk.ReadResourceRequest, resp *tfsdk.ReadResourceResponse) {
+	tflog.Debug(ctx, "Reading issue field configuration item")
+
+	var state jiraIssueFieldConfigurationItemResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	tflog.Debug(ctx, "Loaded issue field configuration item from state", map[string]interface{}{
+		"issueFieldConfigurationItem": fmt.Sprintf("%+v, %+v", state, *state.Item),
+	})
+
+	issueFieldConfigurationId, _ := strconv.Atoi(state.IssueFieldConfiguration.Value)
+	issueFieldConfigurationItem, res, err := r.p.jira.Issue.Field.Configuration.Item.Gets(ctx, issueFieldConfigurationId, 0, 50)
+	if err != nil {
+		var resBody string
+		if res != nil {
+			resBody = res.Bytes.String()
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get issue field configuration item, got error: %s\n%s", err, resBody))
+		return
+	}
+
+	for _, i := range issueFieldConfigurationItem.Values {
+		if i.ID == state.Item.ID.Value {
+			state.Item = &jiraIssueFieldConfigurationItem{
+				ID:          types.String{Value: state.Item.ID.Value},
+				Description: types.String{Value: i.Description},
+				IsHidden:    types.Bool{Value: i.IsHidden},
+				IsRequired:  types.Bool{Value: i.IsRequired},
+				Renderer:    types.String{Value: i.Renderer},
+			}
+		}
+	}
+	tflog.Debug(ctx, "Retrieved issue field configuration item from API state")
+
+	state.ID = types.String{Value: createIssueFieldConfigurationItemID(state.IssueFieldConfiguration.Value, state.Item.ID.Value)}
+
+	tflog.Debug(ctx, "Storing issue field configuration item into the state", map[string]interface{}{
+		"issueFieldConfigurationItem": fmt.Sprintf("%+v, %+v", state, *state.Item),
+	})
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *jiraIssueFieldConfigurationItemResource) Update(ctx context.Context, req tfsdk.UpdateResourceRequest, resp *tfsdk.UpdateResourceResponse) {
+	tflog.Debug(ctx, "Updating issue field configuration item")
+
+	var plan jiraIssueFieldConfigurationItemResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	tflog.Debug(ctx, "Loaded issue field configuration item plan", map[string]interface{}{
+		"issueFieldConfigurationItemPlan": fmt.Sprintf("%+v, %+v", plan, *plan.Item),
+	})
+
+	var state jiraIssueFieldConfigurationItemResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	tflog.Debug(ctx, "Loaded issue field configuration item from state", map[string]interface{}{
+		"issueFieldConfigurationItemState": fmt.Sprintf("%+v, %+v", state, *state.Item),
+	})
+
+	updateRequestPayload := models.UpdateFieldConfigurationItemPayloadScheme{
+		FieldConfigurationItems: []*models.FieldConfigurationItemScheme{
+			{
+				ID:          plan.Item.ID.Value,
+				IsHidden:    plan.Item.IsHidden.Value,
+				IsRequired:  plan.Item.IsRequired.Value,
+				Description: plan.Item.Description.Value,
+				Renderer:    plan.Item.Renderer.Value,
+			},
+		},
+	}
+
+	issueFieldConfigurationId, _ := strconv.Atoi(plan.IssueFieldConfiguration.Value)
+	res, err := r.p.jira.Issue.Field.Configuration.Item.Update(ctx, issueFieldConfigurationId, &updateRequestPayload)
+	if err != nil {
+		var resBody string
+		if err != nil {
+			resBody = res.Bytes.String()
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update issue field configuration item, got error: %s\n%s", err, resBody))
+		return
+	}
+
+	items, res, err := r.p.jira.Issue.Field.Configuration.Item.Gets(ctx, issueFieldConfigurationId, 0, 50)
+	if err != nil {
+		var resBody string
+		if res != nil {
+			resBody = res.Bytes.String()
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get issue field configuration items, got error: %s\n%s", err, resBody))
+		return
+	}
+
+	for _, i := range items.Values {
+		if i.ID == plan.Item.ID.Value {
+			plan.Item = &jiraIssueFieldConfigurationItem{
+				ID:          types.String{Value: plan.Item.ID.Value},
+				Description: types.String{Value: i.Description},
+				IsHidden:    types.Bool{Value: i.IsHidden},
+				IsRequired:  types.Bool{Value: i.IsRequired},
+				Renderer:    types.String{Value: i.Renderer},
+			}
+		}
+	}
+
+	tflog.Debug(ctx, "Updated issue field configuration item in API state")
+
+	plan.ID = types.String{Value: state.ID.Value}
+
+	tflog.Debug(ctx, "Storing issue field configuration item plan into the state")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *jiraIssueFieldConfigurationItemResource) Delete(ctx context.Context, req tfsdk.DeleteResourceRequest, resp *tfsdk.DeleteResourceResponse) {
+	tflog.Warn(ctx, "Cannot destroy atlassian_jira_issue_field_configuration_item resource. Terraform will only remove this resource from the state file.")
+	// If a Resource type Delete method is completed without error, the framework will automatically remove the resource.
+}
+
+func createIssueFieldConfigurationItemID(issueFieldConfiguration, item string) string {
+	return strings.Join([]string{issueFieldConfiguration, item}, "-")
+}
+
+func (r *jiraIssueFieldConfigurationItemResource) checkIssueFieldConfigurationItemRenderable(ctx context.Context, p *jiraIssueFieldConfigurationItemResourceModel) error {
+	var isRenderable bool
+	searchPayload := models.FieldSearchOptionsScheme{
+		IDs:    []string{p.Item.ID.Value},
+		Expand: []string{"isLocked"},
+	}
+
+	itemDetails, res, err := r.p.jira.Issue.Field.Search(ctx, &searchPayload, 0, 1)
+	if err != nil {
+		var resBody string
+		if res != nil {
+			resBody = res.Bytes.String()
+		}
+		return fmt.Errorf(" Unable to find issue field configuration item, got error: %s\n%s", err, resBody)
+	}
+	tflog.Debug(ctx, "Found issue field configuration item details", map[string]interface{}{
+		"issueFieldConfigurationItem": fmt.Sprintf("%+v, %+v", itemDetails.Values[0], itemDetails.Values[0].Schema),
+	})
+
+	if itemDetails.Values[0].ID != p.Item.ID.Value {
+		return fmt.Errorf(" Search result does not match issue field configuration item with ID: [%s]", p.Item.ID.Value)
+	}
+
+	if itemDetails.Values[0].IsLocked {
+		return fmt.Errorf(" Tried to set a renderer for the locked item with ID: [%s]", p.Item.ID.Value)
+	}
+
+	isRenderable = strings.Contains(strings.Join(renderableItemTypes, ","), itemDetails.Values[0].Schema.Type)
+	if !isRenderable {
+		return fmt.Errorf(" Tried to set a renderer for the non-renderable item with ID: [%s]", p.Item.ID.Value)
+	}
+
+	return nil
+}

--- a/internal/provider/resource_jira_issue_field_configuration_item_test.go
+++ b/internal/provider/resource_jira_issue_field_configuration_item_test.go
@@ -1,0 +1,437 @@
+package atlassian
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+var (
+	resourceName = "atlassian_jira_issue_field_configuration_item.test"
+)
+
+func TestAccJiraIssueFieldConfigurationItem_Basic(t *testing.T) {
+	randomName := acctest.RandomWithPrefix("tf-test-issue-field-configuration-item")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIssueFieldConfigurationItemConfig_basic(resourceName, randomName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "item.description"),
+					resource.TestCheckResourceAttrSet(resourceName, "item.is_hidden"),
+					resource.TestCheckResourceAttrSet(resourceName, "item.is_required"),
+					resource.TestCheckResourceAttr(resourceName, "item.id", "customfield_10009"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccIssueFieldConfigurationItemImportConfig,
+			},
+		},
+	})
+}
+
+func TestAccJiraIssueFieldConfigurationItem_Description(t *testing.T) {
+	randomName := acctest.RandomWithPrefix("tf-test-issue-field-configuration-item")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIssueFieldConfigurationItemConfig_description(resourceName, randomName, "description1"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "item.description", "description1"),
+				),
+			},
+			{
+				Config: testAccIssueFieldConfigurationItemConfig_description(resourceName, randomName, "description2"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "item.description", "description2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccJiraIssueFieldConfigurationItem_IsHidden(t *testing.T) {
+	randomName := acctest.RandomWithPrefix("tf-test-issue-field-configuration-item")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIssueFieldConfigurationItemConfig_ishidden(resourceName, randomName, "false"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "item.is_hidden", "false"),
+				),
+			},
+			{
+				Config: testAccIssueFieldConfigurationItemConfig_ishidden(resourceName, randomName, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "item.is_hidden", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccJiraIssueFieldConfigurationItem_IsRequired(t *testing.T) {
+	randomName := acctest.RandomWithPrefix("tf-test-issue-field-configuration-item")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIssueFieldConfigurationItemConfig_isrequired(resourceName, randomName, "false"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "item.is_required", "false"),
+				),
+			},
+			{
+				Config: testAccIssueFieldConfigurationItemConfig_isrequired(resourceName, randomName, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "item.is_required", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccJiraIssueFieldConfigurationItem_Renderer(t *testing.T) {
+	randomName := acctest.RandomWithPrefix("tf-test-issue-field-configuration-item")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIssueFieldConfigurationItemConfig_renderer(resourceName, randomName, "text-renderer"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "item.renderer", "text-renderer"),
+				),
+			},
+			{
+				Config: testAccIssueFieldConfigurationItemConfig_renderer(resourceName, randomName, "wiki-renderer"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "item.renderer", "wiki-renderer"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccJiraIssueFieldConfigurationItem_RendererErrors(t *testing.T) {
+	randomName := acctest.RandomWithPrefix("tf-test-issue-field-configuration-item")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccIssueFieldConfigurationItemConfig_renderererrors(resourceName, randomName, "autocomplete-renderer"),
+				ExpectError: regexp.MustCompile(`Value must be one of`),
+			},
+		},
+	})
+}
+
+func TestAccJiraIssueFieldConfigurationItem_NonRenderableErrors(t *testing.T) {
+	randomName := acctest.RandomWithPrefix("tf-test-issue-field-configuration-item")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Actual End field
+			{
+				Config:      testAccIssueFieldConfigurationItemConfig_nonrenderableerrors(resourceName, randomName, "customfield_10009"),
+				ExpectError: regexp.MustCompile("Tried to set a renderer for the non-renderable item"),
+			},
+			// Assignee field
+			{
+				Config:      testAccIssueFieldConfigurationItemConfig_nonrenderableerrors(resourceName, randomName, "assignee"),
+				ExpectError: regexp.MustCompile("Tried to set a renderer for the non-renderable item"),
+			},
+			// Reporter field
+			{
+				Config:      testAccIssueFieldConfigurationItemConfig_nonrenderableerrors(resourceName, randomName, "reporter"),
+				ExpectError: regexp.MustCompile("Tried to set a renderer for the non-renderable item"),
+			},
+		},
+	})
+}
+
+func TestAccJiraIssueFieldConfigurationItem_LockedErrors(t *testing.T) {
+	randomName := acctest.RandomWithPrefix("tf-test-issue-field-configuration-item")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Request Type
+			{
+				Config:      testAccIssueFieldConfigurationItemConfig_lockederrors(resourceName, randomName, "customfield_10010"),
+				ExpectError: regexp.MustCompile("Tried to set a renderer for the locked item"),
+			},
+			// Epic Name field
+			{
+				Config:      testAccIssueFieldConfigurationItemConfig_lockederrors(resourceName, randomName, "customfield_10011"),
+				ExpectError: regexp.MustCompile("Tried to set a renderer for the locked item"),
+			},
+			// Epic Color field
+			{
+				Config:      testAccIssueFieldConfigurationItemConfig_lockederrors(resourceName, randomName, "customfield_10013"),
+				ExpectError: regexp.MustCompile("Tried to set a renderer for the locked item"),
+			},
+			// Epic Link field
+			{
+				Config:      testAccIssueFieldConfigurationItemConfig_nonrenderableerrors(resourceName, randomName, "customfield_10014"),
+				ExpectError: regexp.MustCompile("Tried to set a renderer for the locked item"),
+			},
+			// Issue Color field
+			{
+				Config:      testAccIssueFieldConfigurationItemConfig_lockederrors(resourceName, randomName, "customfield_10017"),
+				ExpectError: regexp.MustCompile("Tried to set a renderer for the locked item"),
+			},
+		},
+	})
+}
+
+func TestAccJiraIssueFieldConfigurationItem_HiddenRequired(t *testing.T) {
+	randomName := acctest.RandomWithPrefix("tf-test-issue-field-configuration-item")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIssueFieldConfigurationItemConfig_hiddenrequired(resourceName, randomName, "true", "false"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "item.is_hidden", "true"),
+					resource.TestCheckResourceAttr(resourceName, "item.is_required", "false"),
+				),
+			},
+			{
+				Config: testAccIssueFieldConfigurationItemConfig_hiddenrequired(resourceName, randomName, "true", "true"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "item.is_hidden", "true"),
+					resource.TestCheckResourceAttr(resourceName, "item.is_required", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccJiraIssueFieldConfigurationItem_ForceNewResource(t *testing.T) {
+	randomName := acctest.RandomWithPrefix("tf-test-issue-field-configuration-item")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIssueFieldConfigurationItemConfig_forcenewresource(resourceName, randomName, "comment"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "item.id", "comment"),
+				),
+			},
+			{
+				Config: testAccIssueFieldConfigurationItemConfig_forcenewresource(resourceName, randomName+"2", "description"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "item.id", "description"),
+				),
+			},
+		},
+	})
+}
+
+func testAccIssueFieldConfigurationItemImportConfig(s *terraform.State) (string, error) {
+	issueFieldConfigurationID := s.RootModule().Resources["atlassian_jira_issue_field_configuration.test"].Primary.Attributes["id"]
+	itemID := s.RootModule().Resources[resourceName].Primary.Attributes["item.id"]
+	return fmt.Sprintf("%s,%s", issueFieldConfigurationID, itemID), nil
+}
+
+func testAccIssueFieldConfigurationItemConfig_basic(resourceName, name string) string {
+	splits := strings.Split(resourceName, ".")
+	return fmt.Sprintf(`
+	resource "atlassian_jira_issue_field_configuration" "test" {
+		name = %[3]q
+	}
+
+	resource %[1]q %[2]q {
+		issue_field_configuration = atlassian_jira_issue_field_configuration.test.id
+		item = {
+			id = "customfield_10009"
+		}
+	}
+	`, splits[0], splits[1], name)
+}
+
+func testAccIssueFieldConfigurationItemConfig_description(resourceName, name, description string) string {
+	splits := strings.Split(resourceName, ".")
+	return fmt.Sprintf(`
+	resource "atlassian_jira_issue_field_configuration" "test" {
+		name = %[3]q
+	}
+
+	resource %[1]q %[2]q {
+		issue_field_configuration = atlassian_jira_issue_field_configuration.test.id
+		item = {
+			id = "customfield_10009"
+			description = %[4]q
+		}
+	}
+	`, splits[0], splits[1], name, description)
+}
+
+func testAccIssueFieldConfigurationItemConfig_ishidden(resourceName, name, isHidden string) string {
+	splits := strings.Split(resourceName, ".")
+	return fmt.Sprintf(`
+	resource "atlassian_jira_issue_field_configuration" "test" {
+		name = %[3]q
+	}
+
+	resource %[1]q %[2]q {
+		issue_field_configuration = atlassian_jira_issue_field_configuration.test.id
+		item = {
+			id = "customfield_10009"
+			is_hidden = %[4]s
+		}
+	}
+	`, splits[0], splits[1], name, isHidden)
+}
+
+func testAccIssueFieldConfigurationItemConfig_isrequired(resourceName, name, isRequired string) string {
+	splits := strings.Split(resourceName, ".")
+	return fmt.Sprintf(`
+	resource "atlassian_jira_issue_field_configuration" "test" {
+		name = %[3]q
+	}
+
+	resource %[1]q %[2]q {
+		issue_field_configuration = atlassian_jira_issue_field_configuration.test.id
+		item = {
+			id = "customfield_10009"
+			is_required = %[4]s
+		}
+	}
+	`, splits[0], splits[1], name, isRequired)
+}
+
+func testAccIssueFieldConfigurationItemConfig_renderer(resourceName, name, renderer string) string {
+	splits := strings.Split(resourceName, ".")
+	return fmt.Sprintf(`
+	resource "atlassian_jira_issue_field_configuration" "test" {
+		name = %[3]q
+	}
+
+	resource %[1]q %[2]q {
+		issue_field_configuration = atlassian_jira_issue_field_configuration.test.id
+		item = {
+			id = "comment"
+			renderer = %[4]q
+		}
+	}
+	`, splits[0], splits[1], name, renderer)
+}
+
+func testAccIssueFieldConfigurationItemConfig_renderererrors(resourceName, name, renderer string) string {
+	splits := strings.Split(resourceName, ".")
+	return fmt.Sprintf(`
+	resource "atlassian_jira_issue_field_configuration" "test" {
+		name = %[3]q
+	}
+
+	resource %[1]q %[2]q {
+		issue_field_configuration = atlassian_jira_issue_field_configuration.test.id
+		item = {
+			id = "comment"
+			renderer = %[4]q
+		}
+	}
+	`, splits[0], splits[1], name, renderer)
+}
+
+func testAccIssueFieldConfigurationItemConfig_nonrenderableerrors(resourceName, name, itemID string) string {
+	splits := strings.Split(resourceName, ".")
+	return fmt.Sprintf(`
+	resource "atlassian_jira_issue_field_configuration" "test" {
+		name = %[3]q
+	}
+
+	resource %[1]q %[2]q {
+		issue_field_configuration = atlassian_jira_issue_field_configuration.test.id
+		item = {
+			id = %[4]q
+			renderer = "text-renderer"
+		}
+	}
+	`, splits[0], splits[1], name, itemID)
+}
+
+func testAccIssueFieldConfigurationItemConfig_lockederrors(resourceName, name, itemId string) string {
+	splits := strings.Split(resourceName, ".")
+	return fmt.Sprintf(`
+	resource "atlassian_jira_issue_field_configuration" "test" {
+		name = %[3]q
+	}
+
+	resource %[1]q %[2]q {
+		issue_field_configuration = atlassian_jira_issue_field_configuration.test.id
+		item = {
+			id = %[4]q
+			renderer = "text-renderer"
+		}
+	}
+	`, splits[0], splits[1], name, itemId)
+}
+
+func testAccIssueFieldConfigurationItemConfig_hiddenrequired(resourceName, name, isHidden, isRequired string) string {
+	splits := strings.Split(resourceName, ".")
+	return fmt.Sprintf(`
+	resource "atlassian_jira_issue_field_configuration" "test" {
+		name = %[3]q
+	}
+
+	resource %[1]q %[2]q {
+		issue_field_configuration = atlassian_jira_issue_field_configuration.test.id
+		item = {
+			id = "comment"
+			is_hidden = %[4]s
+			is_required = %[5]s
+		}
+	}
+	`, splits[0], splits[1], name, isHidden, isRequired)
+}
+
+func testAccIssueFieldConfigurationItemConfig_forcenewresource(resourceName, name, itemId string) string {
+	splits := strings.Split(resourceName, ".")
+	return fmt.Sprintf(`
+	resource "atlassian_jira_issue_field_configuration" %[3]q {
+		name = %[3]q
+	}
+
+	resource %[1]q %[2]q {
+		issue_field_configuration = atlassian_jira_issue_field_configuration.%[3]s.id
+		item = {
+			id = %[4]q
+		}
+	}
+	`, splits[0], splits[1], name, itemId)
+}

--- a/templates/resources/jira_issue_field_configuration_item.md.tmpl
+++ b/templates/resources/jira_issue_field_configuration_item.md.tmpl
@@ -1,0 +1,56 @@
+---
+page_title: "Atlassian Cloud: {{ .Name }}"
+subcategory: "Jira Cloud"
+description: |-
+  Manages {{ .Name }}.
+---
+
+# {{ .Type }}: {{ .Name }}
+
+Provides an `{{ .Name }}` resource.
+
+Learn more about [Jira Issue Field Configuration Items](https://support.atlassian.com/jira-cloud-administration/docs/change-a-field-configuration/).
+
+See more details about the [Jira Cloud Platform REST API for Issue Field Configuration Items](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-field-configurations/#api-rest-api-3-fieldconfiguration-id-fields-get).
+
+~> **Note** `terraform destroy` does not delete `{{ .Name }}` but does remove the resource from Terraform state.
+
+-> **Note** `{{ .Name }}` can only reference [`atlassian_jira_issue_field_configuration`](https://registry.terraform.io/providers/openscientia/atlassian/latest/docs/resources/jira_issue_field_configuration) used in [company-managed (classic) projects](https://support.atlassian.com/jira-software-cloud/docs/what-are-team-managed-and-company-managed-projects/).
+
+## Example Usage
+
+### Basic
+
+{{ .Name | printf "examples/resources/%s/basic.tf" | tffile }}
+
+### Hide or Show fields
+
+-> **Note** `item.is_hidden` can be set to `true` to ensure that the field does not appear on any `atlassian_jira_issue_screen` (i.e. issue operation screens, workflow transition screens) where a specific `atlassian_jira_issue_field_configuration` applies. See more [details](https://support.atlassian.com/jira-cloud-administration/docs/specify-field-behavior/#Hide-or-show-a-field).
+
+~> **Note** Hiding a field in the `{{ .Name }}` resource is distinct from not adding a field to a `atlassian_jira_issue_screen`. Fields hidden through the `{{ .Name }}` resource will be hidden in all applicable screens, regardless of whether or not they have been added to any `atlassian_jira_issue_screen`.
+
+{{ .Name | printf "examples/resources/%s/ishidden.tf" | tffile }}
+
+### Required or Optional fields
+
+-> **Note** `item.is_required` can be set to `true` to ensures that Jira validates the field has been given a value whenever an issue is edited. Alternatively, set to `false` to make a field optional if no value is required. See more [details](https://support.atlassian.com/jira-cloud-administration/docs/specify-field-behavior/#Make-a-field-required-or-optional).
+
+~> **Note** If you make a field required, ensure that the field is present on all Create Issue `atlassian_jira_issue_screen` resources associated to different `atlassian_jira_issue_type` or projects.
+
+{{ .Name | printf "examples/resources/%s/isrequired.tf" | tffile }}
+
+### Renderers
+
+-> **Note** `item.renderer` can be set for text fields to the default text renderer ([`text-renderer`](https://support.atlassian.com/jira-cloud-administration/docs/configure-renderers/#Default-text-renderer)) or wiki style renderer ([`wiki-renderer`](https://support.atlassian.com/jira-cloud-administration/docs/configure-renderers/#Wiki-style-renderer)). However, `item.renderer` cannot be set for multi-select fields using the [autocomplete renderer](https://support.atlassian.com/jira-cloud-administration/docs/configure-renderers/#Autocomplete-and-select-list-renderers) or [select list renderer](https://support.atlassian.com/jira-cloud-administration/docs/configure-renderers/#Autocomplete-and-select-list-renderers). See more [details](https://support.atlassian.com/jira-cloud-administration/docs/configure-renderers/).
+
+{{ .Name | printf "examples/resources/%s/renderers.tf" | tffile }}
+
+{{ .SchemaMarkdown | trimspace }}
+
+## Import
+
+`{{ .Name }}` can be imported using the `issue_field_configuration` and `item.id` separated by a comma (`,`) e.g.,
+
+```sh
+$ terraform import {{ .Name | printf "%s.foo 10000,customfield_10000"}}
+```


### PR DESCRIPTION
Closes #73 

```
TF_ACC=1 go test -v -cover -timeout 120m ./... -run TestAccJiraIssueFieldConfigurationItem
?   	github.com/openscientia/terraform-provider-atlassian	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/issuelabels	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/prlabels	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/repolabels	[no test files]
=== RUN   TestAccJiraIssueFieldConfigurationItem_Basic
=== PAUSE TestAccJiraIssueFieldConfigurationItem_Basic
=== RUN   TestAccJiraIssueFieldConfigurationItem_Description
=== PAUSE TestAccJiraIssueFieldConfigurationItem_Description
=== RUN   TestAccJiraIssueFieldConfigurationItem_IsHidden
=== PAUSE TestAccJiraIssueFieldConfigurationItem_IsHidden
=== RUN   TestAccJiraIssueFieldConfigurationItem_IsRequired
=== PAUSE TestAccJiraIssueFieldConfigurationItem_IsRequired
=== RUN   TestAccJiraIssueFieldConfigurationItem_Renderer
=== PAUSE TestAccJiraIssueFieldConfigurationItem_Renderer
=== RUN   TestAccJiraIssueFieldConfigurationItem_RendererErrors
=== PAUSE TestAccJiraIssueFieldConfigurationItem_RendererErrors
=== RUN   TestAccJiraIssueFieldConfigurationItem_NonRenderableErrors
=== PAUSE TestAccJiraIssueFieldConfigurationItem_NonRenderableErrors
=== RUN   TestAccJiraIssueFieldConfigurationItem_LockedErrors
=== PAUSE TestAccJiraIssueFieldConfigurationItem_LockedErrors
=== RUN   TestAccJiraIssueFieldConfigurationItem_HiddenRequired
=== PAUSE TestAccJiraIssueFieldConfigurationItem_HiddenRequired
=== RUN   TestAccJiraIssueFieldConfigurationItem_ForceNewResource
=== PAUSE TestAccJiraIssueFieldConfigurationItem_ForceNewResource
=== CONT  TestAccJiraIssueFieldConfigurationItem_Basic
=== CONT  TestAccJiraIssueFieldConfigurationItem_RendererErrors
=== CONT  TestAccJiraIssueFieldConfigurationItem_IsRequired
=== CONT  TestAccJiraIssueFieldConfigurationItem_Renderer
=== CONT  TestAccJiraIssueFieldConfigurationItem_IsHidden
=== CONT  TestAccJiraIssueFieldConfigurationItem_ForceNewResource
=== CONT  TestAccJiraIssueFieldConfigurationItem_Description
=== CONT  TestAccJiraIssueFieldConfigurationItem_LockedErrors
=== CONT  TestAccJiraIssueFieldConfigurationItem_NonRenderableErrors
=== CONT  TestAccJiraIssueFieldConfigurationItem_HiddenRequired
--- PASS: TestAccJiraIssueFieldConfigurationItem_RendererErrors (0.25s)
--- PASS: TestAccJiraIssueFieldConfigurationItem_Basic (2.96s)
--- PASS: TestAccJiraIssueFieldConfigurationItem_LockedErrors (3.11s)
--- PASS: TestAccJiraIssueFieldConfigurationItem_IsHidden (3.17s)
--- PASS: TestAccJiraIssueFieldConfigurationItem_ForceNewResource (3.49s)
--- PASS: TestAccJiraIssueFieldConfigurationItem_Description (3.49s)
--- PASS: TestAccJiraIssueFieldConfigurationItem_HiddenRequired (4.69s)
--- PASS: TestAccJiraIssueFieldConfigurationItem_NonRenderableErrors (5.20s)
--- PASS: TestAccJiraIssueFieldConfigurationItem_Renderer (9.47s)
--- PASS: TestAccJiraIssueFieldConfigurationItem_IsRequired (15.82s)
PASS
coverage: 16.5% of statements
ok  	github.com/openscientia/terraform-provider-atlassian/internal/provider	16.022s	coverage: 16.5% of statements
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_plan_modification	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_validation	[no test files]
```