### PR TITLE
docs(registry): replace invalid link in `atlassian_jira_issue_type` resource documentation

### DIFF
--- a/.changelog/74.txt
+++ b/.changelog/74.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/atlassian_jira_issue_type: Updated documentation to fix invalid link in [`Example Usage`](https://registry.terraform.io/providers/openscientia/atlassian/latest/docs/resources/jira_issue_type#example-usage) section 
+```

--- a/docs/resources/jira_issue_type.md
+++ b/docs/resources/jira_issue_type.md
@@ -15,7 +15,7 @@ See more details about the [Jira Cloud REST API for Issue Types](https://develop
 
 ## Example Usage
 
--> **Note** Issue types are added to the default [`atlassian_issue_type_scheme`](/docs/resources/issue_type_scheme.md).
+-> **Note** Issue types are added to the default [`atlassian_jira_issue_type_scheme`](https://registry.terraform.io/providers/openscientia/atlassian/latest/docs/resources/jira_issue_type_scheme).
 
 ### Base issue type
 

--- a/templates/resources/jira_issue_type.md.tmpl
+++ b/templates/resources/jira_issue_type.md.tmpl
@@ -15,7 +15,7 @@ See more details about the [Jira Cloud REST API for Issue Types](https://develop
 
 ## Example Usage
 
--> **Note** Issue types are added to the default [`atlassian_issue_type_scheme`](/docs/resources/issue_type_scheme.md).
+-> **Note** Issue types are added to the default [`atlassian_jira_issue_type_scheme`](https://registry.terraform.io/providers/openscientia/atlassian/latest/docs/resources/jira_issue_type_scheme).
 
 ### Base issue type
 


### PR DESCRIPTION
Closes #74 