### PR TITLE
refactor(framework): fix breaking changes with terraform plugin framework v0.11.1

### DIFF
--- a/internal/provider/data_source_jira_issue_field_configuration.go
+++ b/internal/provider/data_source_jira_issue_field_configuration.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -14,7 +16,7 @@ import (
 
 type (
 	jiraIssueFieldConfigurationDataSource struct {
-		p provider
+		p atlassianProvider
 	}
 
 	jiraIssueFieldConfigurationDataSourceType struct{}
@@ -27,8 +29,8 @@ type (
 )
 
 var (
-	_ tfsdk.DataSource     = (*jiraIssueFieldConfigurationDataSource)(nil)
-	_ tfsdk.DataSourceType = (*jiraIssueFieldConfigurationDataSourceType)(nil)
+	_ datasource.DataSource   = (*jiraIssueFieldConfigurationDataSource)(nil)
+	_ provider.DataSourceType = (*jiraIssueFieldConfigurationDataSourceType)(nil)
 )
 
 func (d *jiraIssueFieldConfigurationDataSourceType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
@@ -55,7 +57,7 @@ func (d *jiraIssueFieldConfigurationDataSourceType) GetSchema(_ context.Context)
 	}, nil
 }
 
-func (d *jiraIssueFieldConfigurationDataSourceType) NewDataSource(_ context.Context, in tfsdk.Provider) (tfsdk.DataSource, diag.Diagnostics) {
+func (d *jiraIssueFieldConfigurationDataSourceType) NewDataSource(_ context.Context, in provider.Provider) (datasource.DataSource, diag.Diagnostics) {
 	provider, diags := convertProviderType(in)
 
 	return &jiraIssueFieldConfigurationDataSource{
@@ -64,7 +66,7 @@ func (d *jiraIssueFieldConfigurationDataSourceType) NewDataSource(_ context.Cont
 
 }
 
-func (d *jiraIssueFieldConfigurationDataSource) Read(ctx context.Context, req tfsdk.ReadDataSourceRequest, resp *tfsdk.ReadDataSourceResponse) {
+func (d *jiraIssueFieldConfigurationDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	tflog.Debug(ctx, "Reading issue field configuration")
 
 	var newState jiraIssueFieldConfigurationDataSourceModel

--- a/internal/provider/data_source_jira_issue_screen.go
+++ b/internal/provider/data_source_jira_issue_screen.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -15,7 +17,7 @@ import (
 type (
 	jiraIssueScreenDataSourceType struct{}
 	jiraIssueScreenDataSource     struct {
-		p provider
+		p atlassianProvider
 	}
 	jiraIssueScreenDataSourceModel struct {
 		ID          types.String `tfsdk:"id"`
@@ -25,8 +27,8 @@ type (
 )
 
 var (
-	_ tfsdk.DataSourceType = jiraIssueScreenDataSourceType{}
-	_ tfsdk.DataSource     = jiraIssueScreenDataSource{}
+	_ provider.DataSourceType = jiraIssueScreenDataSourceType{}
+	_ datasource.DataSource   = jiraIssueScreenDataSource{}
 )
 
 func (jiraIssueScreenDataSourceType) GetSchema(context.Context) (tfsdk.Schema, diag.Diagnostics) {
@@ -56,7 +58,7 @@ func (jiraIssueScreenDataSourceType) GetSchema(context.Context) (tfsdk.Schema, d
 	}, nil
 }
 
-func (d jiraIssueScreenDataSourceType) NewDataSource(ctx context.Context, in tfsdk.Provider) (tfsdk.DataSource, diag.Diagnostics) {
+func (d jiraIssueScreenDataSourceType) NewDataSource(ctx context.Context, in provider.Provider) (datasource.DataSource, diag.Diagnostics) {
 	provider, diags := convertProviderType(in)
 
 	return jiraIssueScreenDataSource{
@@ -64,7 +66,7 @@ func (d jiraIssueScreenDataSourceType) NewDataSource(ctx context.Context, in tfs
 	}, diags
 }
 
-func (d jiraIssueScreenDataSource) Read(ctx context.Context, req tfsdk.ReadDataSourceRequest, resp *tfsdk.ReadDataSourceResponse) {
+func (d jiraIssueScreenDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	tflog.Debug(ctx, "Reading issue screen")
 	var newState jiraIssueScreenDataSourceModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &newState)...)

--- a/internal/provider/data_source_jira_issue_type.go
+++ b/internal/provider/data_source_jira_issue_type.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-var _ tfsdk.DataSourceType = jiraIssueTypeDataSourceType{}
-var _ tfsdk.DataSource = jiraIssueTypeDataSource{}
+var _ provider.DataSourceType = jiraIssueTypeDataSourceType{}
+var _ datasource.DataSource = jiraIssueTypeDataSource{}
 
 type jiraIssueTypeDataSourceType struct{}
 
@@ -24,7 +26,7 @@ type jiraIssueTypeDataSourceData struct {
 }
 
 type jiraIssueTypeDataSource struct {
-	p provider
+	p atlassianProvider
 }
 
 func (t jiraIssueTypeDataSourceType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
@@ -67,7 +69,7 @@ func (t jiraIssueTypeDataSourceType) GetSchema(ctx context.Context) (tfsdk.Schem
 	}, nil
 }
 
-func (t jiraIssueTypeDataSourceType) NewDataSource(ctx context.Context, in tfsdk.Provider) (tfsdk.DataSource, diag.Diagnostics) {
+func (t jiraIssueTypeDataSourceType) NewDataSource(ctx context.Context, in provider.Provider) (datasource.DataSource, diag.Diagnostics) {
 	provider, diags := convertProviderType(in)
 
 	return jiraIssueTypeDataSource{
@@ -75,7 +77,7 @@ func (t jiraIssueTypeDataSourceType) NewDataSource(ctx context.Context, in tfsdk
 	}, diags
 }
 
-func (d jiraIssueTypeDataSource) Read(ctx context.Context, req tfsdk.ReadDataSourceRequest, resp *tfsdk.ReadDataSourceResponse) {
+func (d jiraIssueTypeDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var data jiraIssueTypeDataSourceData
 
 	diags := req.Config.Get(ctx, &data)

--- a/internal/provider/data_source_jira_issue_type_scheme.go
+++ b/internal/provider/data_source_jira_issue_type_scheme.go
@@ -5,13 +5,15 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-var _ tfsdk.DataSourceType = jiraIssueTypeSchemeDataSourceType{}
-var _ tfsdk.DataSource = jiraIssueTypeSchemeDataSource{}
+var _ provider.DataSourceType = jiraIssueTypeSchemeDataSourceType{}
+var _ datasource.DataSource = jiraIssueTypeSchemeDataSource{}
 
 type jiraIssueTypeSchemeDataSourceType struct{}
 
@@ -24,7 +26,7 @@ type jiraIssueTypeSchemeDataSourceData struct {
 }
 
 type jiraIssueTypeSchemeDataSource struct {
-	p provider
+	p atlassianProvider
 }
 
 func (t jiraIssueTypeSchemeDataSourceType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
@@ -64,7 +66,7 @@ func (t jiraIssueTypeSchemeDataSourceType) GetSchema(ctx context.Context) (tfsdk
 	}, nil
 }
 
-func (t jiraIssueTypeSchemeDataSourceType) NewDataSource(ctx context.Context, in tfsdk.Provider) (tfsdk.DataSource, diag.Diagnostics) {
+func (t jiraIssueTypeSchemeDataSourceType) NewDataSource(ctx context.Context, in provider.Provider) (datasource.DataSource, diag.Diagnostics) {
 	provider, diags := convertProviderType(in)
 
 	return jiraIssueTypeSchemeDataSource{
@@ -72,7 +74,7 @@ func (t jiraIssueTypeSchemeDataSourceType) NewDataSource(ctx context.Context, in
 	}, diags
 }
 
-func (d jiraIssueTypeSchemeDataSource) Read(ctx context.Context, req tfsdk.ReadDataSourceRequest, resp *tfsdk.ReadDataSourceResponse) {
+func (d jiraIssueTypeSchemeDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var data jiraIssueTypeSchemeDataSourceData
 
 	diags := req.Config.Get(ctx, &data)

--- a/internal/provider/data_source_jira_issue_type_screen_scheme.go
+++ b/internal/provider/data_source_jira_issue_type_screen_scheme.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -14,7 +16,7 @@ import (
 
 type (
 	jiraIssueTypeScreenSchemeDataSource struct {
-		p provider
+		p atlassianProvider
 	}
 
 	jiraIssueTypeScreenSchemeDataSourceType struct{}
@@ -28,8 +30,8 @@ type (
 )
 
 var (
-	_ tfsdk.DataSource     = (*jiraIssueTypeScreenSchemeDataSource)(nil)
-	_ tfsdk.DataSourceType = (*jiraIssueTypeScreenSchemeDataSourceType)(nil)
+	_ datasource.DataSource   = (*jiraIssueTypeScreenSchemeDataSource)(nil)
+	_ provider.DataSourceType = (*jiraIssueTypeScreenSchemeDataSourceType)(nil)
 )
 
 func (d *jiraIssueTypeScreenSchemeDataSourceType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
@@ -81,7 +83,7 @@ func (d *jiraIssueTypeScreenSchemeDataSourceType) GetSchema(_ context.Context) (
 	}, nil
 }
 
-func (d *jiraIssueTypeScreenSchemeDataSourceType) NewDataSource(_ context.Context, in tfsdk.Provider) (tfsdk.DataSource, diag.Diagnostics) {
+func (d *jiraIssueTypeScreenSchemeDataSourceType) NewDataSource(_ context.Context, in provider.Provider) (datasource.DataSource, diag.Diagnostics) {
 	provider, diags := convertProviderType(in)
 
 	return &jiraIssueTypeScreenSchemeDataSource{
@@ -89,7 +91,7 @@ func (d *jiraIssueTypeScreenSchemeDataSourceType) NewDataSource(_ context.Contex
 	}, diags
 }
 
-func (d *jiraIssueTypeScreenSchemeDataSource) Read(ctx context.Context, req tfsdk.ReadDataSourceRequest, resp *tfsdk.ReadDataSourceResponse) {
+func (d *jiraIssueTypeScreenSchemeDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	tflog.Debug(ctx, "Reading issue type screen scheme")
 
 	var newState jiraIssueTypeScreenSchemeDataSourceModel

--- a/internal/provider/data_source_jira_screen_scheme.go
+++ b/internal/provider/data_source_jira_screen_scheme.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -14,7 +16,7 @@ import (
 
 type (
 	jiraScreenSchemeDataSource struct {
-		p provider
+		p atlassianProvider
 	}
 
 	jiraScreenSchemeDataSourceType struct{}
@@ -28,8 +30,8 @@ type (
 )
 
 var (
-	_ tfsdk.DataSource     = (*jiraScreenSchemeDataSource)(nil)
-	_ tfsdk.DataSourceType = (*jiraScreenSchemeDataSourceType)(nil)
+	_ datasource.DataSource   = (*jiraScreenSchemeDataSource)(nil)
+	_ provider.DataSourceType = (*jiraScreenSchemeDataSourceType)(nil)
 )
 
 func (d *jiraScreenSchemeDataSourceType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
@@ -88,7 +90,7 @@ func (d *jiraScreenSchemeDataSourceType) GetSchema(_ context.Context) (tfsdk.Sch
 	}, nil
 }
 
-func (d *jiraScreenSchemeDataSourceType) NewDataSource(_ context.Context, in tfsdk.Provider) (tfsdk.DataSource, diag.Diagnostics) {
+func (d *jiraScreenSchemeDataSourceType) NewDataSource(_ context.Context, in provider.Provider) (datasource.DataSource, diag.Diagnostics) {
 	provider, diags := convertProviderType(in)
 
 	return &jiraScreenSchemeDataSource{
@@ -96,7 +98,7 @@ func (d *jiraScreenSchemeDataSourceType) NewDataSource(_ context.Context, in tfs
 	}, diags
 }
 
-func (d *jiraScreenSchemeDataSource) Read(ctx context.Context, req tfsdk.ReadDataSourceRequest, resp *tfsdk.ReadDataSourceResponse) {
+func (d *jiraScreenSchemeDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	tflog.Debug(ctx, "Reading screen scheme")
 
 	var newState jiraScreenSchemeDataSourceModel

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -6,16 +6,16 @@ import (
 	"os"
 
 	jira "github.com/ctreminiom/go-atlassian/jira/v3"
-	"github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_validation"
-
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_validation"
 )
 
-var _ tfsdk.Provider = &provider{}
+var _ provider.Provider = &atlassianProvider{}
 
-type provider struct {
+type atlassianProvider struct {
 	jira *jira.Client
 
 	configured bool
@@ -23,7 +23,7 @@ type provider struct {
 	version string
 }
 
-func (p *provider) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func (p *atlassianProvider) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
 	return tfsdk.Schema{
 		MarkdownDescription: "Atlassian",
 
@@ -62,7 +62,7 @@ type providerData struct {
 	ApiToken types.String `tfsdk:"apitoken"`
 }
 
-func (p *provider) Configure(ctx context.Context, req tfsdk.ConfigureProviderRequest, resp *tfsdk.ConfigureProviderResponse) {
+func (p *atlassianProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
 	var data providerData
 	diags := req.Config.Get(ctx, &data)
 	resp.Diagnostics.Append(diags...)
@@ -158,8 +158,8 @@ func (p *provider) Configure(ctx context.Context, req tfsdk.ConfigureProviderReq
 	p.configured = true
 }
 
-func (p *provider) GetResources(ctx context.Context) (map[string]tfsdk.ResourceType, diag.Diagnostics) {
-	return map[string]tfsdk.ResourceType{
+func (p *atlassianProvider) GetResources(ctx context.Context) (map[string]provider.ResourceType, diag.Diagnostics) {
+	return map[string]provider.ResourceType{
 		"atlassian_jira_issue_field_configuration_item":   &jiraIssueFieldConfigurationItemResourceType{},
 		"atlassian_jira_issue_field_configuration":        &jiraIssueFieldConfigurationResourceType{},
 		"atlassian_jira_issue_field_configuration_scheme": &jiraIssueFieldConfigurationSchemeResourceType{},
@@ -171,8 +171,8 @@ func (p *provider) GetResources(ctx context.Context) (map[string]tfsdk.ResourceT
 	}, nil
 }
 
-func (p *provider) GetDataSources(ctx context.Context) (map[string]tfsdk.DataSourceType, diag.Diagnostics) {
-	return map[string]tfsdk.DataSourceType{
+func (p *atlassianProvider) GetDataSources(ctx context.Context) (map[string]provider.DataSourceType, diag.Diagnostics) {
+	return map[string]provider.DataSourceType{
 		"atlassian_jira_issue_field_configuration": &jiraIssueFieldConfigurationDataSourceType{},
 		"atlassian_jira_issue_screen":              jiraIssueScreenDataSourceType{},
 		"atlassian_jira_issue_type":                jiraIssueTypeDataSourceType{},
@@ -182,9 +182,9 @@ func (p *provider) GetDataSources(ctx context.Context) (map[string]tfsdk.DataSou
 	}, nil
 }
 
-func New(version string) func() tfsdk.Provider {
-	return func() tfsdk.Provider {
-		return &provider{
+func New(version string) func() provider.Provider {
+	return func() provider.Provider {
+		return &atlassianProvider{
 			version: version,
 		}
 	}
@@ -195,17 +195,17 @@ func New(version string) func() tfsdk.Provider {
 // this helper can be skipped and the provider type can be directly type
 // asserted (e.g. provider: in.(*provider)), however using this can prevent
 // potential panics.
-func convertProviderType(in tfsdk.Provider) (provider, diag.Diagnostics) {
+func convertProviderType(in provider.Provider) (atlassianProvider, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	p, ok := in.(*provider)
+	p, ok := in.(*atlassianProvider)
 
 	if !ok {
 		diags.AddError(
 			"Unexpected Provider Instance Type",
 			fmt.Sprintf("While creating the data source or resource, an unexpected provider type (%T) was received. This is always a bug in the provider code and should be reported to the provider developers.", p),
 		)
-		return provider{}, diags
+		return atlassianProvider{}, diags
 	}
 
 	if p == nil {
@@ -213,7 +213,7 @@ func convertProviderType(in tfsdk.Provider) (provider, diag.Diagnostics) {
 			"Unexpected Provider Instance Type",
 			"While creating the data source or resource, an unexpected empty provider instance was received. This is always a bug in the provider code and should be reported to the provider developers.",
 		)
-		return provider{}, diags
+		return atlassianProvider{}, diags
 	}
 
 	return *p, diags

--- a/internal/provider/resource_jira_issue_field_configuration.go
+++ b/internal/provider/resource_jira_issue_field_configuration.go
@@ -8,6 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -16,7 +18,7 @@ import (
 
 type (
 	jiraIssueFieldConfigurationResource struct {
-		p provider
+		p atlassianProvider
 	}
 
 	jiraIssueFieldConfigurationResourceType struct{}
@@ -29,9 +31,9 @@ type (
 )
 
 var (
-	_ tfsdk.Resource                = (*jiraIssueFieldConfigurationResource)(nil)
-	_ tfsdk.ResourceType            = (*jiraIssueFieldConfigurationResourceType)(nil)
-	_ tfsdk.ResourceWithImportState = (*jiraIssueFieldConfigurationResource)(nil)
+	_ resource.Resource                = (*jiraIssueFieldConfigurationResource)(nil)
+	_ provider.ResourceType            = (*jiraIssueFieldConfigurationResourceType)(nil)
+	_ resource.ResourceWithImportState = (*jiraIssueFieldConfigurationResource)(nil)
 )
 
 func (*jiraIssueFieldConfigurationResourceType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
@@ -71,7 +73,7 @@ func (*jiraIssueFieldConfigurationResourceType) GetSchema(_ context.Context) (tf
 	}, nil
 }
 
-func (r *jiraIssueFieldConfigurationResourceType) NewResource(ctx context.Context, in tfsdk.Provider) (tfsdk.Resource, diag.Diagnostics) {
+func (r *jiraIssueFieldConfigurationResourceType) NewResource(ctx context.Context, in provider.Provider) (resource.Resource, diag.Diagnostics) {
 	provider, diags := convertProviderType(in)
 
 	return &jiraIssueFieldConfigurationResource{
@@ -80,11 +82,11 @@ func (r *jiraIssueFieldConfigurationResourceType) NewResource(ctx context.Contex
 
 }
 
-func (r *jiraIssueFieldConfigurationResource) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
-	tfsdk.ResourceImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+func (r *jiraIssueFieldConfigurationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func (r *jiraIssueFieldConfigurationResource) Create(ctx context.Context, req tfsdk.CreateResourceRequest, resp *tfsdk.CreateResourceResponse) {
+func (r *jiraIssueFieldConfigurationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	tflog.Debug(ctx, "Creating issue field configuration")
 
 	if !r.p.configured {
@@ -122,7 +124,7 @@ func (r *jiraIssueFieldConfigurationResource) Create(ctx context.Context, req tf
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
-func (r *jiraIssueFieldConfigurationResource) Read(ctx context.Context, req tfsdk.ReadResourceRequest, resp *tfsdk.ReadResourceResponse) {
+func (r *jiraIssueFieldConfigurationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	tflog.Debug(ctx, "Reading issue field configuration")
 
 	var state jiraIssueFieldConfigurationResourceModel
@@ -155,7 +157,7 @@ func (r *jiraIssueFieldConfigurationResource) Read(ctx context.Context, req tfsd
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *jiraIssueFieldConfigurationResource) Update(ctx context.Context, req tfsdk.UpdateResourceRequest, resp *tfsdk.UpdateResourceResponse) {
+func (r *jiraIssueFieldConfigurationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	tflog.Debug(ctx, "Updating issue field configuration")
 
 	var plan jiraIssueFieldConfigurationResourceModel
@@ -194,7 +196,7 @@ func (r *jiraIssueFieldConfigurationResource) Update(ctx context.Context, req tf
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
-func (r *jiraIssueFieldConfigurationResource) Delete(ctx context.Context, req tfsdk.DeleteResourceRequest, resp *tfsdk.DeleteResourceResponse) {
+func (r *jiraIssueFieldConfigurationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	tflog.Debug(ctx, "Deleting issue field configuration")
 
 	var state jiraIssueFieldConfigurationResourceModel

--- a/internal/provider/resource_jira_issue_field_configuration_item.go
+++ b/internal/provider/resource_jira_issue_field_configuration_item.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -18,7 +20,7 @@ import (
 
 type (
 	jiraIssueFieldConfigurationItemResource struct {
-		p provider
+		p atlassianProvider
 	}
 
 	jiraIssueFieldConfigurationItemResourceType struct{}
@@ -39,10 +41,10 @@ type (
 )
 
 var (
-	_                   tfsdk.Resource                = (*jiraIssueFieldConfigurationItemResource)(nil)
-	_                   tfsdk.ResourceType            = (*jiraIssueFieldConfigurationItemResourceType)(nil)
-	_                   tfsdk.ResourceWithImportState = (*jiraIssueFieldConfigurationItemResource)(nil)
-	renderableItemTypes                               = []string{"string", "comments-page"}
+	_                   resource.Resource                = (*jiraIssueFieldConfigurationItemResource)(nil)
+	_                   provider.ResourceType            = (*jiraIssueFieldConfigurationItemResourceType)(nil)
+	_                   resource.ResourceWithImportState = (*jiraIssueFieldConfigurationItemResource)(nil)
+	renderableItemTypes                                  = []string{"string", "comments-page"}
 )
 
 func (*jiraIssueFieldConfigurationItemResourceType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
@@ -61,7 +63,7 @@ func (*jiraIssueFieldConfigurationItemResourceType) GetSchema(_ context.Context)
 				Required:            true,
 				Type:                types.StringType,
 				PlanModifiers: tfsdk.AttributePlanModifiers{
-					tfsdk.RequiresReplace(),
+					resource.RequiresReplace(),
 				},
 			},
 			"item": {
@@ -77,7 +79,7 @@ func (*jiraIssueFieldConfigurationItemResourceType) GetSchema(_ context.Context)
 								stringvalidator.RegexMatches(regexp.MustCompile(`^customfield_[0-9]{5}$|^[a-zA-Z]*$`), ""),
 							},
 							PlanModifiers: tfsdk.AttributePlanModifiers{
-								tfsdk.RequiresReplace(),
+								resource.RequiresReplace(),
 							},
 						},
 						"description": {
@@ -117,7 +119,7 @@ func (*jiraIssueFieldConfigurationItemResourceType) GetSchema(_ context.Context)
 	}, nil
 }
 
-func (r *jiraIssueFieldConfigurationItemResourceType) NewResource(ctx context.Context, in tfsdk.Provider) (tfsdk.Resource, diag.Diagnostics) {
+func (r *jiraIssueFieldConfigurationItemResourceType) NewResource(ctx context.Context, in provider.Provider) (resource.Resource, diag.Diagnostics) {
 	provider, diags := convertProviderType(in)
 
 	return &jiraIssueFieldConfigurationItemResource{
@@ -125,7 +127,7 @@ func (r *jiraIssueFieldConfigurationItemResourceType) NewResource(ctx context.Co
 	}, diags
 }
 
-func (r *jiraIssueFieldConfigurationItemResource) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
+func (r *jiraIssueFieldConfigurationItemResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idParts := strings.Split(req.ID, ",")
 	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
 		resp.Diagnostics.AddError("Unexpected Import Identifier",
@@ -137,7 +139,7 @@ func (r *jiraIssueFieldConfigurationItemResource) ImportState(ctx context.Contex
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("item").AtName("id"), idParts[1])...)
 }
 
-func (r *jiraIssueFieldConfigurationItemResource) Create(ctx context.Context, req tfsdk.CreateResourceRequest, resp *tfsdk.CreateResourceResponse) {
+func (r *jiraIssueFieldConfigurationItemResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	tflog.Debug(ctx, "Creating issue field configuration item")
 
 	if !r.p.configured {
@@ -218,7 +220,7 @@ func (r *jiraIssueFieldConfigurationItemResource) Create(ctx context.Context, re
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
-func (r *jiraIssueFieldConfigurationItemResource) Read(ctx context.Context, req tfsdk.ReadResourceRequest, resp *tfsdk.ReadResourceResponse) {
+func (r *jiraIssueFieldConfigurationItemResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	tflog.Debug(ctx, "Reading issue field configuration item")
 
 	var state jiraIssueFieldConfigurationItemResourceModel
@@ -262,7 +264,7 @@ func (r *jiraIssueFieldConfigurationItemResource) Read(ctx context.Context, req 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *jiraIssueFieldConfigurationItemResource) Update(ctx context.Context, req tfsdk.UpdateResourceRequest, resp *tfsdk.UpdateResourceResponse) {
+func (r *jiraIssueFieldConfigurationItemResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	tflog.Debug(ctx, "Updating issue field configuration item")
 
 	var plan jiraIssueFieldConfigurationItemResourceModel
@@ -336,7 +338,7 @@ func (r *jiraIssueFieldConfigurationItemResource) Update(ctx context.Context, re
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
-func (r *jiraIssueFieldConfigurationItemResource) Delete(ctx context.Context, req tfsdk.DeleteResourceRequest, resp *tfsdk.DeleteResourceResponse) {
+func (r *jiraIssueFieldConfigurationItemResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	tflog.Warn(ctx, "Cannot destroy atlassian_jira_issue_field_configuration_item resource. Terraform will only remove this resource from the state file.")
 	// If a Resource type Delete method is completed without error, the framework will automatically remove the resource.
 }

--- a/internal/provider/resource_jira_issue_field_configuration_scheme.go
+++ b/internal/provider/resource_jira_issue_field_configuration_scheme.go
@@ -8,6 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -16,7 +18,7 @@ import (
 
 type (
 	jiraIssueFieldConfigurationSchemeResource struct {
-		p provider
+		p atlassianProvider
 	}
 
 	jiraIssueFieldConfigurationSchemeResourceType struct{}
@@ -29,9 +31,9 @@ type (
 )
 
 var (
-	_ tfsdk.Resource                = (*jiraIssueFieldConfigurationSchemeResource)(nil)
-	_ tfsdk.ResourceType            = (*jiraIssueFieldConfigurationSchemeResourceType)(nil)
-	_ tfsdk.ResourceWithImportState = (*jiraIssueFieldConfigurationSchemeResource)(nil)
+	_ resource.Resource                = (*jiraIssueFieldConfigurationSchemeResource)(nil)
+	_ provider.ResourceType            = (*jiraIssueFieldConfigurationSchemeResourceType)(nil)
+	_ resource.ResourceWithImportState = (*jiraIssueFieldConfigurationSchemeResource)(nil)
 )
 
 func (*jiraIssueFieldConfigurationSchemeResourceType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
@@ -71,7 +73,7 @@ func (*jiraIssueFieldConfigurationSchemeResourceType) GetSchema(_ context.Contex
 	}, nil
 }
 
-func (r *jiraIssueFieldConfigurationSchemeResourceType) NewResource(ctx context.Context, in tfsdk.Provider) (tfsdk.Resource, diag.Diagnostics) {
+func (r *jiraIssueFieldConfigurationSchemeResourceType) NewResource(ctx context.Context, in provider.Provider) (resource.Resource, diag.Diagnostics) {
 	provider, diags := convertProviderType(in)
 
 	return &jiraIssueFieldConfigurationSchemeResource{
@@ -79,11 +81,11 @@ func (r *jiraIssueFieldConfigurationSchemeResourceType) NewResource(ctx context.
 	}, diags
 }
 
-func (r *jiraIssueFieldConfigurationSchemeResource) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
-	tfsdk.ResourceImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+func (r *jiraIssueFieldConfigurationSchemeResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func (r *jiraIssueFieldConfigurationSchemeResource) Create(ctx context.Context, req tfsdk.CreateResourceRequest, resp *tfsdk.CreateResourceResponse) {
+func (r *jiraIssueFieldConfigurationSchemeResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	tflog.Debug(ctx, "Creating issue field configuration scheme")
 
 	if !r.p.configured {
@@ -121,7 +123,7 @@ func (r *jiraIssueFieldConfigurationSchemeResource) Create(ctx context.Context, 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
-func (r *jiraIssueFieldConfigurationSchemeResource) Read(ctx context.Context, req tfsdk.ReadResourceRequest, resp *tfsdk.ReadResourceResponse) {
+func (r *jiraIssueFieldConfigurationSchemeResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	tflog.Debug(ctx, "Reading issue field configuration scheme")
 
 	var state jiraIssueFieldConfigurationSchemeResourceModel
@@ -156,7 +158,7 @@ func (r *jiraIssueFieldConfigurationSchemeResource) Read(ctx context.Context, re
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *jiraIssueFieldConfigurationSchemeResource) Update(ctx context.Context, req tfsdk.UpdateResourceRequest, resp *tfsdk.UpdateResourceResponse) {
+func (r *jiraIssueFieldConfigurationSchemeResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	tflog.Debug(ctx, "Updating issue field configuration scheme")
 
 	var plan jiraIssueFieldConfigurationSchemeResourceModel
@@ -195,7 +197,7 @@ func (r *jiraIssueFieldConfigurationSchemeResource) Update(ctx context.Context, 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
-func (r *jiraIssueFieldConfigurationSchemeResource) Delete(ctx context.Context, req tfsdk.DeleteResourceRequest, resp *tfsdk.DeleteResourceResponse) {
+func (r *jiraIssueFieldConfigurationSchemeResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	tflog.Debug(ctx, "Deleting issue field configuration scheme")
 
 	var state jiraIssueFieldConfigurationSchemeResourceModel

--- a/internal/provider/resource_jira_issue_screen.go
+++ b/internal/provider/resource_jira_issue_screen.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -15,7 +17,7 @@ import (
 
 type (
 	jiraIssueScreenResource struct {
-		p provider
+		p atlassianProvider
 	}
 
 	jiraIssueScreenResourceType struct{}
@@ -28,9 +30,9 @@ type (
 )
 
 var (
-	_ tfsdk.Resource                = jiraIssueScreenResource{}
-	_ tfsdk.ResourceType            = jiraIssueScreenResourceType{}
-	_ tfsdk.ResourceWithImportState = jiraIssueScreenResource{}
+	_ resource.Resource                = jiraIssueScreenResource{}
+	_ provider.ResourceType            = jiraIssueScreenResourceType{}
+	_ resource.ResourceWithImportState = jiraIssueScreenResource{}
 )
 
 func (jiraIssueScreenResourceType) GetSchema(context.Context) (tfsdk.Schema, diag.Diagnostics) {
@@ -67,7 +69,7 @@ func (jiraIssueScreenResourceType) GetSchema(context.Context) (tfsdk.Schema, dia
 	}, nil
 }
 
-func (jiraIssueScreenResourceType) NewResource(ctx context.Context, in tfsdk.Provider) (tfsdk.Resource, diag.Diagnostics) {
+func (jiraIssueScreenResourceType) NewResource(ctx context.Context, in provider.Provider) (resource.Resource, diag.Diagnostics) {
 	provider, diags := convertProviderType(in)
 
 	return jiraIssueScreenResource{
@@ -76,11 +78,11 @@ func (jiraIssueScreenResourceType) NewResource(ctx context.Context, in tfsdk.Pro
 
 }
 
-func (jiraIssueScreenResource) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
-	tfsdk.ResourceImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+func (jiraIssueScreenResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func (r jiraIssueScreenResource) Create(ctx context.Context, req tfsdk.CreateResourceRequest, resp *tfsdk.CreateResourceResponse) {
+func (r jiraIssueScreenResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	tflog.Debug(ctx, "Creating issue screen resource")
 
 	if !r.p.configured {
@@ -123,7 +125,7 @@ func (r jiraIssueScreenResource) Create(ctx context.Context, req tfsdk.CreateRes
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
-func (r jiraIssueScreenResource) Read(ctx context.Context, req tfsdk.ReadResourceRequest, resp *tfsdk.ReadResourceResponse) {
+func (r jiraIssueScreenResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	tflog.Debug(ctx, "Reading issue screen resource")
 
 	var state jiraIssueScreenResourceModel
@@ -156,7 +158,7 @@ func (r jiraIssueScreenResource) Read(ctx context.Context, req tfsdk.ReadResourc
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r jiraIssueScreenResource) Update(ctx context.Context, req tfsdk.UpdateResourceRequest, resp *tfsdk.UpdateResourceResponse) {
+func (r jiraIssueScreenResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	tflog.Debug(ctx, "Updating issue screen")
 
 	var plan jiraIssueScreenResourceModel
@@ -201,7 +203,7 @@ func (r jiraIssueScreenResource) Update(ctx context.Context, req tfsdk.UpdateRes
 	resp.Diagnostics.Append(resp.State.Set(ctx, &updatedState)...)
 }
 
-func (r jiraIssueScreenResource) Delete(ctx context.Context, req tfsdk.DeleteResourceRequest, resp *tfsdk.DeleteResourceResponse) {
+func (r jiraIssueScreenResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	tflog.Debug(ctx, "Deleting issue screen resource")
 
 	var state jiraIssueScreenResourceModel

--- a/internal/provider/resource_jira_issue_type.go
+++ b/internal/provider/resource_jira_issue_type.go
@@ -4,24 +4,24 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ctreminiom/go-atlassian/pkg/infra/models"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
 	"github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_validation"
-
-	models "github.com/ctreminiom/go-atlassian/pkg/infra/models"
 )
 
-var _ tfsdk.Resource = jiraIssueTypeResource{}
-var _ tfsdk.ResourceType = jiraIssueTypeResourceType{}
-var _ tfsdk.ResourceWithImportState = jiraIssueTypeResource{}
+var _ resource.Resource = jiraIssueTypeResource{}
+var _ provider.ResourceType = jiraIssueTypeResourceType{}
+var _ resource.ResourceWithImportState = jiraIssueTypeResource{}
 
 type jiraIssueTypeResourceType struct{}
 
 type jiraIssueTypeResource struct {
-	p provider
+	p atlassianProvider
 }
 
 type jiraIssueTypeResourceData struct {
@@ -46,7 +46,7 @@ func (t jiraIssueTypeResourceType) GetSchema(ctx context.Context) (tfsdk.Schema,
 			"name": {
 				MarkdownDescription: "The name of the issue type. The maximum length is 60 characters.",
 				PlanModifiers: tfsdk.AttributePlanModifiers{
-					tfsdk.UseStateForUnknown(),
+					resource.UseStateForUnknown(),
 				},
 				Required: true,
 				Type:     types.StringType,
@@ -90,7 +90,7 @@ func (t jiraIssueTypeResourceType) GetSchema(ctx context.Context) (tfsdk.Schema,
 	}, nil
 }
 
-func (t jiraIssueTypeResourceType) NewResource(ctx context.Context, in tfsdk.Provider) (tfsdk.Resource, diag.Diagnostics) {
+func (t jiraIssueTypeResourceType) NewResource(ctx context.Context, in provider.Provider) (resource.Resource, diag.Diagnostics) {
 	provider, diags := convertProviderType(in)
 
 	return jiraIssueTypeResource{
@@ -98,11 +98,11 @@ func (t jiraIssueTypeResourceType) NewResource(ctx context.Context, in tfsdk.Pro
 	}, diags
 }
 
-func (r jiraIssueTypeResource) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
-	tfsdk.ResourceImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+func (r jiraIssueTypeResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func (r jiraIssueTypeResource) Create(ctx context.Context, req tfsdk.CreateResourceRequest, resp *tfsdk.CreateResourceResponse) {
+func (r jiraIssueTypeResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	if !r.p.configured {
 		resp.Diagnostics.AddError(
 			"Provider not configured",
@@ -184,7 +184,7 @@ func (r jiraIssueTypeResource) Create(ctx context.Context, req tfsdk.CreateResou
 	}
 }
 
-func (r jiraIssueTypeResource) Read(ctx context.Context, req tfsdk.ReadResourceRequest, resp *tfsdk.ReadResourceResponse) {
+func (r jiraIssueTypeResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state jiraIssueTypeResourceData
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -217,7 +217,7 @@ func (r jiraIssueTypeResource) Read(ctx context.Context, req tfsdk.ReadResourceR
 	}
 }
 
-func (r jiraIssueTypeResource) Update(ctx context.Context, req tfsdk.UpdateResourceRequest, resp *tfsdk.UpdateResourceResponse) {
+func (r jiraIssueTypeResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan jiraIssueTypeResourceData
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -260,7 +260,7 @@ func (r jiraIssueTypeResource) Update(ctx context.Context, req tfsdk.UpdateResou
 	}
 }
 
-func (r jiraIssueTypeResource) Delete(ctx context.Context, req tfsdk.DeleteResourceRequest, resp *tfsdk.DeleteResourceResponse) {
+func (r jiraIssueTypeResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var state jiraIssueTypeResourceData
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/resource_jira_issue_type_scheme.go
+++ b/internal/provider/resource_jira_issue_type_scheme.go
@@ -5,23 +5,23 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/ctreminiom/go-atlassian/pkg/infra/models"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-
 	"github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_validation"
-
-	models "github.com/ctreminiom/go-atlassian/pkg/infra/models"
 )
 
-var _ tfsdk.Resource = jiraIssueTypeSchemeResource{}
-var _ tfsdk.ResourceWithImportState = jiraIssueTypeSchemeResource{}
-var _ tfsdk.ResourceType = jiraIssueTypeSchemeResourceType{}
+var _ resource.Resource = jiraIssueTypeSchemeResource{}
+var _ resource.ResourceWithImportState = jiraIssueTypeSchemeResource{}
+var _ provider.ResourceType = jiraIssueTypeSchemeResourceType{}
 
 type jiraIssueTypeSchemeResource struct {
-	p provider
+	p atlassianProvider
 }
 type jiraIssueTypeSchemeResourceType struct{}
 type jiraIssueTypeSchemeResourceData struct {
@@ -76,7 +76,7 @@ func (t jiraIssueTypeSchemeResourceType) GetSchema(ctx context.Context) (tfsdk.S
 	}, nil
 }
 
-func (t jiraIssueTypeSchemeResourceType) NewResource(ctx context.Context, in tfsdk.Provider) (tfsdk.Resource, diag.Diagnostics) {
+func (t jiraIssueTypeSchemeResourceType) NewResource(ctx context.Context, in provider.Provider) (resource.Resource, diag.Diagnostics) {
 	provider, diags := convertProviderType(in)
 
 	return jiraIssueTypeSchemeResource{
@@ -84,11 +84,11 @@ func (t jiraIssueTypeSchemeResourceType) NewResource(ctx context.Context, in tfs
 	}, diags
 }
 
-func (r jiraIssueTypeSchemeResource) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
-	tfsdk.ResourceImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+func (r jiraIssueTypeSchemeResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func (r jiraIssueTypeSchemeResource) Create(ctx context.Context, req tfsdk.CreateResourceRequest, resp *tfsdk.CreateResourceResponse) {
+func (r jiraIssueTypeSchemeResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	if !r.p.configured {
 		resp.Diagnostics.AddError(
 			"Provider not configured",
@@ -155,7 +155,7 @@ func (r jiraIssueTypeSchemeResource) Create(ctx context.Context, req tfsdk.Creat
 	}
 }
 
-func (r jiraIssueTypeSchemeResource) Read(ctx context.Context, req tfsdk.ReadResourceRequest, resp *tfsdk.ReadResourceResponse) {
+func (r jiraIssueTypeSchemeResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state jiraIssueTypeSchemeResourceData
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -202,7 +202,7 @@ func (r jiraIssueTypeSchemeResource) Read(ctx context.Context, req tfsdk.ReadRes
 	}
 }
 
-func (r jiraIssueTypeSchemeResource) Update(ctx context.Context, req tfsdk.UpdateResourceRequest, resp *tfsdk.UpdateResourceResponse) {
+func (r jiraIssueTypeSchemeResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan jiraIssueTypeSchemeResourceData
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -282,7 +282,7 @@ func (r jiraIssueTypeSchemeResource) Update(ctx context.Context, req tfsdk.Updat
 	}
 }
 
-func (r jiraIssueTypeSchemeResource) Delete(ctx context.Context, req tfsdk.DeleteResourceRequest, resp *tfsdk.DeleteResourceResponse) {
+func (r jiraIssueTypeSchemeResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var state jiraIssueTypeSchemeResourceData
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/resource_jira_issue_type_screen_scheme.go
+++ b/internal/provider/resource_jira_issue_type_screen_scheme.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -17,7 +19,7 @@ import (
 
 type (
 	jiraIssueTypeScreenSchemeResource struct {
-		p provider
+		p atlassianProvider
 	}
 
 	jiraIssueTypeScreenSchemeResourceType struct{}
@@ -36,9 +38,9 @@ type (
 )
 
 var (
-	_ tfsdk.Resource                = (*jiraIssueTypeSchemeResource)(nil)
-	_ tfsdk.ResourceType            = (*jiraScreenSchemeResourceType)(nil)
-	_ tfsdk.ResourceWithImportState = (*jiraIssueTypeScreenSchemeResource)(nil)
+	_ resource.Resource                = (*jiraIssueTypeSchemeResource)(nil)
+	_ provider.ResourceType            = (*jiraScreenSchemeResourceType)(nil)
+	_ resource.ResourceWithImportState = (*jiraIssueTypeScreenSchemeResource)(nil)
 )
 
 func (*jiraIssueTypeScreenSchemeResourceType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
@@ -100,7 +102,7 @@ func (*jiraIssueTypeScreenSchemeResourceType) GetSchema(_ context.Context) (tfsd
 	}, nil
 }
 
-func (r *jiraIssueTypeScreenSchemeResourceType) NewResource(ctx context.Context, in tfsdk.Provider) (tfsdk.Resource, diag.Diagnostics) {
+func (r *jiraIssueTypeScreenSchemeResourceType) NewResource(ctx context.Context, in provider.Provider) (resource.Resource, diag.Diagnostics) {
 	provider, diags := convertProviderType(in)
 
 	return &jiraIssueTypeScreenSchemeResource{
@@ -108,11 +110,11 @@ func (r *jiraIssueTypeScreenSchemeResourceType) NewResource(ctx context.Context,
 	}, diags
 }
 
-func (r *jiraIssueTypeScreenSchemeResource) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
-	tfsdk.ResourceImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+func (r *jiraIssueTypeScreenSchemeResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func (r *jiraIssueTypeScreenSchemeResource) Create(ctx context.Context, req tfsdk.CreateResourceRequest, resp *tfsdk.CreateResourceResponse) {
+func (r *jiraIssueTypeScreenSchemeResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	tflog.Debug(ctx, "Creating issue type screen scheme")
 
 	if !r.p.configured {
@@ -178,7 +180,7 @@ func (r *jiraIssueTypeScreenSchemeResource) Create(ctx context.Context, req tfsd
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
-func (r *jiraIssueTypeScreenSchemeResource) Read(ctx context.Context, req tfsdk.ReadResourceRequest, resp *tfsdk.ReadResourceResponse) {
+func (r *jiraIssueTypeScreenSchemeResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	tflog.Debug(ctx, "Reading issue type screen scheme")
 
 	var state jiraIssueTypeScreenSchemeResourceModel
@@ -229,7 +231,7 @@ func (r *jiraIssueTypeScreenSchemeResource) Read(ctx context.Context, req tfsdk.
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *jiraIssueTypeScreenSchemeResource) Update(ctx context.Context, req tfsdk.UpdateResourceRequest, resp *tfsdk.UpdateResourceResponse) {
+func (r *jiraIssueTypeScreenSchemeResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	tflog.Debug(ctx, "Updating issue type screen scheme")
 
 	var plan jiraIssueTypeScreenSchemeResourceModel
@@ -282,7 +284,7 @@ func (r *jiraIssueTypeScreenSchemeResource) Update(ctx context.Context, req tfsd
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
-func (r *jiraIssueTypeScreenSchemeResource) Delete(ctx context.Context, req tfsdk.DeleteResourceRequest, resp *tfsdk.DeleteResourceResponse) {
+func (r *jiraIssueTypeScreenSchemeResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	tflog.Debug(ctx, "Deleting issue type screen scheme")
 
 	var state jiraIssueTypeScreenSchemeResourceModel

--- a/internal/provider/resource_jira_screen_scheme.go
+++ b/internal/provider/resource_jira_screen_scheme.go
@@ -5,20 +5,21 @@ import (
 	"fmt"
 	"strconv"
 
-	models "github.com/ctreminiom/go-atlassian/pkg/infra/models"
+	"github.com/ctreminiom/go-atlassian/pkg/infra/models"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_plan_modification"
 )
 
 type (
 	jiraScreenSchemeResource struct {
-		p provider
+		p atlassianProvider
 	}
 
 	jiraScreenSchemeResourceType struct{}
@@ -38,9 +39,9 @@ type (
 )
 
 var (
-	_ tfsdk.Resource                = (*jiraScreenSchemeResource)(nil)
-	_ tfsdk.ResourceType            = (*jiraScreenSchemeResourceType)(nil)
-	_ tfsdk.ResourceWithImportState = (*jiraScreenSchemeResource)(nil)
+	_ resource.Resource                = (*jiraScreenSchemeResource)(nil)
+	_ provider.ResourceType            = (*jiraScreenSchemeResourceType)(nil)
+	_ resource.ResourceWithImportState = (*jiraScreenSchemeResource)(nil)
 )
 
 func (*jiraScreenSchemeResourceType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
@@ -118,7 +119,7 @@ func (*jiraScreenSchemeResourceType) GetSchema(_ context.Context) (tfsdk.Schema,
 	}, nil
 }
 
-func (r *jiraScreenSchemeResourceType) NewResource(ctx context.Context, in tfsdk.Provider) (tfsdk.Resource, diag.Diagnostics) {
+func (r *jiraScreenSchemeResourceType) NewResource(ctx context.Context, in provider.Provider) (resource.Resource, diag.Diagnostics) {
 	provider, diags := convertProviderType(in)
 
 	return &jiraScreenSchemeResource{
@@ -126,14 +127,14 @@ func (r *jiraScreenSchemeResourceType) NewResource(ctx context.Context, in tfsdk
 	}, diags
 }
 
-func (r *jiraScreenSchemeResource) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
-	tfsdk.ResourceImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+func (r *jiraScreenSchemeResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 	// Must initialise "singleNestedAttributes" to avoid "unhandled null values" error when calling (tfsdk.Plan).Get
 	screens := jiraScreenSchemeTypesModel{}
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("screens"), screens)...)
 }
 
-func (r *jiraScreenSchemeResource) Create(ctx context.Context, req tfsdk.CreateResourceRequest, resp *tfsdk.CreateResourceResponse) {
+func (r *jiraScreenSchemeResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	tflog.Debug(ctx, "Creating screen scheme resource")
 
 	if !r.p.configured {
@@ -188,7 +189,7 @@ func (r *jiraScreenSchemeResource) Create(ctx context.Context, req tfsdk.CreateR
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
-func (r *jiraScreenSchemeResource) Read(ctx context.Context, req tfsdk.ReadResourceRequest, resp *tfsdk.ReadResourceResponse) {
+func (r *jiraScreenSchemeResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	tflog.Debug(ctx, "Reading screen scheme resource")
 
 	var state jiraScreenSchemeResourceModel
@@ -224,7 +225,7 @@ func (r *jiraScreenSchemeResource) Read(ctx context.Context, req tfsdk.ReadResou
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *jiraScreenSchemeResource) Update(ctx context.Context, req tfsdk.UpdateResourceRequest, resp *tfsdk.UpdateResourceResponse) {
+func (r *jiraScreenSchemeResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	tflog.Debug(ctx, "Updating screen scheme")
 
 	var plan jiraScreenSchemeResourceModel
@@ -276,7 +277,7 @@ func (r *jiraScreenSchemeResource) Update(ctx context.Context, req tfsdk.UpdateR
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
-func (r *jiraScreenSchemeResource) Delete(ctx context.Context, req tfsdk.DeleteResourceRequest, resp *tfsdk.DeleteResourceResponse) {
+func (r *jiraScreenSchemeResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	tflog.Debug(ctx, "Deleting screen scheme resource")
 
 	var state jiraScreenSchemeResourceModel


### PR DESCRIPTION
Closes #84 
Relates #81 
Relates [hashicorp/terraform-plugin-framework#432](https://github.com/hashicorp/terraform-plugin-framework/pull/432)
Relates [hashicorp/terraform-plugin-framework#434](https://github.com/hashicorp/terraform-plugin-framework/pull/434)

```
TF_ACC=1 go test -v -cover -timeout 120m ./... -run TestAccJira
?   	github.com/openscientia/terraform-provider-atlassian	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/issuelabels	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/prlabels	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/repolabels	[no test files]
=== RUN   TestAccJiraIssueFieldConfigurationDataSource_Basic
=== PAUSE TestAccJiraIssueFieldConfigurationDataSource_Basic
=== RUN   TestAccJiraIssueScreen_DataSource_Basic
--- PASS: TestAccJiraIssueScreen_DataSource_Basic (1.74s)
=== RUN   TestAccJiraIssueScreen_DataSource_ErrorCases
--- PASS: TestAccJiraIssueScreen_DataSource_ErrorCases (0.12s)
=== RUN   TestAccJiraIssueTypeSchemeDataSource
--- PASS: TestAccJiraIssueTypeSchemeDataSource (1.95s)
=== RUN   TestAccJiraIssueTypeScreenSchemeDataSource_Basic
=== PAUSE TestAccJiraIssueTypeScreenSchemeDataSource_Basic
=== RUN   TestAccJiraIssueTypeDataSource
--- PASS: TestAccJiraIssueTypeDataSource (1.32s)
=== RUN   TestAccJiraScreenSchemeDataSource_Basic
=== PAUSE TestAccJiraScreenSchemeDataSource_Basic
=== RUN   TestAccJiraIssueFieldConfigurationItem_Basic
=== PAUSE TestAccJiraIssueFieldConfigurationItem_Basic
=== RUN   TestAccJiraIssueFieldConfigurationItem_Description
=== PAUSE TestAccJiraIssueFieldConfigurationItem_Description
=== RUN   TestAccJiraIssueFieldConfigurationItem_IsHidden
=== PAUSE TestAccJiraIssueFieldConfigurationItem_IsHidden
=== RUN   TestAccJiraIssueFieldConfigurationItem_IsRequired
=== PAUSE TestAccJiraIssueFieldConfigurationItem_IsRequired
=== RUN   TestAccJiraIssueFieldConfigurationItem_Renderer
=== PAUSE TestAccJiraIssueFieldConfigurationItem_Renderer
=== RUN   TestAccJiraIssueFieldConfigurationItem_RendererErrors
=== PAUSE TestAccJiraIssueFieldConfigurationItem_RendererErrors
=== RUN   TestAccJiraIssueFieldConfigurationItem_NonRenderableErrors
=== PAUSE TestAccJiraIssueFieldConfigurationItem_NonRenderableErrors
=== RUN   TestAccJiraIssueFieldConfigurationItem_LockedErrors
=== PAUSE TestAccJiraIssueFieldConfigurationItem_LockedErrors
=== RUN   TestAccJiraIssueFieldConfigurationItem_HiddenRequired
=== PAUSE TestAccJiraIssueFieldConfigurationItem_HiddenRequired
=== RUN   TestAccJiraIssueFieldConfigurationItem_ForceNewResource
=== PAUSE TestAccJiraIssueFieldConfigurationItem_ForceNewResource
=== RUN   TestAccJiraIssueFieldConfigurationScheme_Basic
=== PAUSE TestAccJiraIssueFieldConfigurationScheme_Basic
=== RUN   TestAccJiraIssueFieldConfigurationScheme_Description
=== PAUSE TestAccJiraIssueFieldConfigurationScheme_Description
=== RUN   TestAccJiraIssueFieldConfiguration_Basic
=== PAUSE TestAccJiraIssueFieldConfiguration_Basic
=== RUN   TestAccJiraIssueFieldConfiguration_Name
=== PAUSE TestAccJiraIssueFieldConfiguration_Name
=== RUN   TestAccJiraIssueFieldConfiguration_Description
=== PAUSE TestAccJiraIssueFieldConfiguration_Description
=== RUN   TestAccJiraIssueScreen
--- PASS: TestAccJiraIssueScreen (2.06s)
=== RUN   TestAccJiraIssueTypeSchemeResource
--- PASS: TestAccJiraIssueTypeSchemeResource (3.93s)
=== RUN   TestAccJiraIssueTypeScreenScheme_Basic
=== PAUSE TestAccJiraIssueTypeScreenScheme_Basic
=== RUN   TestAccJiraIssueTypeScreenScheme_Description
=== PAUSE TestAccJiraIssueTypeScreenScheme_Description
=== RUN   TestAccJiraIssueTypeScreenScheme_DefaultMapping
=== PAUSE TestAccJiraIssueTypeScreenScheme_DefaultMapping
=== RUN   TestAccJiraIssueTypeScreenScheme_IssueTypeMappings
=== PAUSE TestAccJiraIssueTypeScreenScheme_IssueTypeMappings
=== RUN   TestAccJiraIssueTypeResource
--- PASS: TestAccJiraIssueTypeResource (2.54s)
=== RUN   TestAccJiraScreenScheme_Basic
=== PAUSE TestAccJiraScreenScheme_Basic
=== RUN   TestAccJiraScreenScheme_Description
=== PAUSE TestAccJiraScreenScheme_Description
=== RUN   TestAccJiraScreenScheme_Screens
=== PAUSE TestAccJiraScreenScheme_Screens
=== CONT  TestAccJiraIssueFieldConfigurationDataSource_Basic
=== CONT  TestAccJiraIssueFieldConfigurationScheme_Basic
=== CONT  TestAccJiraIssueFieldConfigurationItem_Renderer
=== CONT  TestAccJiraIssueFieldConfigurationItem_ForceNewResource
=== CONT  TestAccJiraIssueFieldConfigurationItem_IsRequired
=== CONT  TestAccJiraIssueFieldConfigurationItem_HiddenRequired
=== CONT  TestAccJiraIssueFieldConfigurationItem_NonRenderableErrors
=== CONT  TestAccJiraIssueFieldConfigurationItem_IsHidden
=== CONT  TestAccJiraIssueFieldConfigurationItem_LockedErrors
=== CONT  TestAccJiraIssueTypeScreenScheme_Description
=== CONT  TestAccJiraIssueFieldConfigurationItem_RendererErrors
--- PASS: TestAccJiraIssueFieldConfigurationScheme_Basic (1.65s)
--- PASS: TestAccJiraIssueFieldConfigurationItem_RendererErrors (0.13s)
=== CONT  TestAccJiraIssueFieldConfigurationItem_Description
=== CONT  TestAccJiraIssueTypeScreenSchemeDataSource_Basic
--- PASS: TestAccJiraIssueTypeScreenScheme_Description (2.82s)
--- PASS: TestAccJiraIssueFieldConfigurationItem_LockedErrors (3.07s)
=== CONT  TestAccJiraScreenSchemeDataSource_Basic
--- PASS: TestAccJiraIssueFieldConfigurationItem_HiddenRequired (3.60s)
=== CONT  TestAccJiraIssueFieldConfigurationItem_Basic
--- PASS: TestAccJiraIssueFieldConfigurationItem_ForceNewResource (3.64s)
=== CONT  TestAccJiraIssueFieldConfiguration_Name
--- PASS: TestAccJiraIssueFieldConfigurationItem_NonRenderableErrors (3.84s)
=== CONT  TestAccJiraIssueTypeScreenScheme_Basic
--- PASS: TestAccJiraIssueFieldConfigurationItem_Renderer (4.16s)
=== CONT  TestAccJiraScreenScheme_Basic
--- PASS: TestAccJiraScreenSchemeDataSource_Basic (1.84s)
=== CONT  TestAccJiraIssueFieldConfiguration_Description
--- PASS: TestAccJiraIssueFieldConfigurationDataSource_Basic (5.14s)
=== CONT  TestAccJiraScreenScheme_Screens
--- PASS: TestAccJiraIssueFieldConfigurationItem_Description (3.37s)
=== CONT  TestAccJiraScreenScheme_Description
--- PASS: TestAccJiraIssueTypeScreenSchemeDataSource_Basic (2.56s)
=== CONT  TestAccJiraIssueFieldConfiguration_Basic
--- PASS: TestAccJiraScreenScheme_Basic (1.53s)
=== CONT  TestAccJiraIssueFieldConfigurationScheme_Description
--- PASS: TestAccJiraIssueFieldConfiguration_Name (2.22s)
=== CONT  TestAccJiraIssueTypeScreenScheme_IssueTypeMappings
=== CONT  TestAccJiraIssueTypeScreenScheme_DefaultMapping
--- PASS: TestAccJiraIssueFieldConfigurationItem_Basic (2.36s)
--- PASS: TestAccJiraIssueTypeScreenScheme_Basic (2.23s)
--- PASS: TestAccJiraIssueFieldConfiguration_Basic (1.68s)
--- PASS: TestAccJiraIssueFieldConfiguration_Description (2.17s)
--- PASS: TestAccJiraScreenScheme_Screens (2.34s)
--- PASS: TestAccJiraScreenScheme_Description (2.33s)
--- PASS: TestAccJiraIssueFieldConfigurationScheme_Description (2.39s)
--- PASS: TestAccJiraIssueTypeScreenScheme_IssueTypeMappings (2.79s)
--- PASS: TestAccJiraIssueTypeScreenScheme_DefaultMapping (2.99s)
--- PASS: TestAccJiraIssueFieldConfigurationItem_IsRequired (9.53s)
--- PASS: TestAccJiraIssueFieldConfigurationItem_IsHidden (15.95s)
PASS
coverage: 67.9% of statements
ok  	github.com/openscientia/terraform-provider-atlassian/internal/provider	29.803s	coverage: 67.9% of statements
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_plan_modification	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_validation	[no test files]
```