### PR TITLE
feat(resource): remove unnecessary plan modifier used in `atlassian_jira_issue_type`

### DIFF
--- a/.changelog/93.txt
+++ b/.changelog/93.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/atlassian_jira_issue_type: Removed unnecessary [UseStateForUnknown](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework@v0.11.1/resource#UseStateForUnknown) plan modifier used with attribute [`name`](https://registry.terraform.io/providers/openscientia/atlassian/latest/docs/resources/jira_issue_type#name)
+```

--- a/internal/provider/resource_jira_issue_type.go
+++ b/internal/provider/resource_jira_issue_type.go
@@ -45,11 +45,8 @@ func (t jiraIssueTypeResourceType) GetSchema(ctx context.Context) (tfsdk.Schema,
 			},
 			"name": {
 				MarkdownDescription: "The name of the issue type. The maximum length is 60 characters.",
-				PlanModifiers: tfsdk.AttributePlanModifiers{
-					resource.UseStateForUnknown(),
-				},
-				Required: true,
-				Type:     types.StringType,
+				Required:            true,
+				Type:                types.StringType,
 				Validators: []tfsdk.AttributeValidator{
 					attribute_validation.StringLengthBetween(0, 60),
 				},


### PR DESCRIPTION
Closes #93 

```
TF_ACC=1 go test -v -cover -timeout 120m ./... -run TestAccJiraIssueTypeResource
?   	github.com/openscientia/terraform-provider-atlassian	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/issuelabels	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/prlabels	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/repolabels	[no test files]
=== RUN   TestAccJiraIssueTypeResource
--- PASS: TestAccJiraIssueTypeResource (2.46s)
PASS
coverage: 10.1% of statements
ok  	github.com/openscientia/terraform-provider-atlassian/internal/provider	2.822s	coverage: 10.1% of statements
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_plan_modification	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_validation	[no test files]
```