### PR TITLE
refactor: replace attribute validators with terraform plugin framework validators

### DIFF
--- a/.changelog/94.txt
+++ b/.changelog/94.txt
@@ -1,0 +1,7 @@
+```release-note:note
+resource/atlassian_jira_issue_type: Replace attribute validators with [`terraform-plugin-framework-validators`](https://github.com/hashicorp/terraform-plugin-framework-validators)
+```
+
+```release-note:note
+resource/atlassian_jira_issue_type_scheme: Replace attribute validators with [`terraform-plugin-framework-validators`](https://github.com/hashicorp/terraform-plugin-framework-validators)
+```

--- a/internal/provider/resource_jira_issue_type.go
+++ b/internal/provider/resource_jira_issue_type.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 
 	"github.com/ctreminiom/go-atlassian/pkg/infra/models"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_validation"
 )
 
 var _ resource.Resource = jiraIssueTypeResource{}
@@ -48,7 +49,7 @@ func (t jiraIssueTypeResourceType) GetSchema(ctx context.Context) (tfsdk.Schema,
 				Required:            true,
 				Type:                types.StringType,
 				Validators: []tfsdk.AttributeValidator{
-					attribute_validation.StringLengthBetween(0, 60),
+					stringvalidator.LengthAtMost(60),
 				},
 			},
 			"description": {
@@ -64,7 +65,7 @@ func (t jiraIssueTypeResourceType) GetSchema(ctx context.Context) (tfsdk.Schema,
 				Computed:            true,
 				Type:                types.StringType,
 				Validators: []tfsdk.AttributeValidator{
-					attribute_validation.StringValues([]string{"standard", "sub-task"}),
+					stringvalidator.OneOf("standard", "sub-task"),
 				},
 			},
 			"hierarchy_level": {
@@ -73,7 +74,7 @@ func (t jiraIssueTypeResourceType) GetSchema(ctx context.Context) (tfsdk.Schema,
 				Computed:            true,
 				Type:                types.Int64Type,
 				Validators: []tfsdk.AttributeValidator{
-					attribute_validation.IntValues([]int{0, -1}),
+					int64validator.OneOf(0, -1),
 				},
 			},
 			"avatar_id": {

--- a/internal/provider/resource_jira_issue_type_scheme.go
+++ b/internal/provider/resource_jira_issue_type_scheme.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/ctreminiom/go-atlassian/pkg/infra/models"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
@@ -13,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_validation"
 )
 
 var _ resource.Resource = jiraIssueTypeSchemeResource{}
@@ -46,7 +46,7 @@ func (t jiraIssueTypeSchemeResourceType) GetSchema(ctx context.Context) (tfsdk.S
 				Required:            true,
 				Type:                types.StringType,
 				Validators: []tfsdk.AttributeValidator{
-					attribute_validation.StringLengthBetween(0, 255),
+					stringvalidator.LengthAtMost(255),
 				},
 			},
 			"description": {
@@ -55,7 +55,7 @@ func (t jiraIssueTypeSchemeResourceType) GetSchema(ctx context.Context) (tfsdk.S
 				Computed:            true,
 				Type:                types.StringType,
 				Validators: []tfsdk.AttributeValidator{
-					attribute_validation.StringLengthBetween(0, 4000),
+					stringvalidator.LengthAtMost(4000),
 				},
 			},
 			"default_issue_type_id": {


### PR DESCRIPTION
Closes #94 

```
TF_ACC=1 go test -v -cover -timeout 120m ./... -run TestAccJiraIssueTypeResource
?   	github.com/openscientia/terraform-provider-atlassian	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/issuelabels	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/prlabels	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/repolabels	[no test files]
=== RUN   TestAccJiraIssueTypeResource
--- PASS: TestAccJiraIssueTypeResource (2.74s)
PASS
coverage: 10.1% of statements
ok  	github.com/openscientia/terraform-provider-atlassian/internal/provider	3.102s	coverage: 10.1% of statements
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_plan_modification	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_validation	[no test files]
```

```
TF_ACC=1 go test -v -cover -timeout 120m ./... -run TestAccJiraIssueTypeSchemeResource
?   	github.com/openscientia/terraform-provider-atlassian	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/issuelabels	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/prlabels	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/repolabels	[no test files]
=== RUN   TestAccJiraIssueTypeSchemeResource
--- PASS: TestAccJiraIssueTypeSchemeResource (3.55s)
PASS
coverage: 15.6% of statements
ok  	github.com/openscientia/terraform-provider-atlassian/internal/provider	3.792s	coverage: 15.6% of statements
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_plan_modification	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_validation	[no test files]
```