### PR TITLE
test: add random names to run acceptance tests in parellel

### DIFF
--- a/.changelog/98.txt
+++ b/.changelog/98.txt
@@ -1,0 +1,7 @@
+```release-note:note
+resource/atlassian_jira_issue_type: Added [randomly generated names](https://github.com/hashicorp/terraform-plugin-sdk/blob/main/helper/acctest/random.go) to execute acceptance tests in [parallel](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2@v2.21.0/helper/resource#ParallelTest)
+```
+
+```release-note:note
+resource/atlassian_jira_issue_type_scheme: Added [randomly generated names](https://github.com/hashicorp/terraform-plugin-sdk/blob/main/helper/acctest/random.go) to execute acceptance tests in [parallel](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2@v2.21.0/helper/resource#ParallelTest)
+```

--- a/internal/provider/resource_jira_issue_type_scheme_test.go
+++ b/internal/provider/resource_jira_issue_type_scheme_test.go
@@ -4,23 +4,23 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccJiraIssueTypeSchemeResource(t *testing.T) {
+	randomName := acctest.RandomWithPrefix("tf-test-issue-type-scheme")
 	resourceName := "atlassian_jira_issue_type_scheme.test"
-	testAttributeNames := []string{"Test Issue Type Scheme 1", "Test Jira Issue Type Scheme 2"}
-
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccJiraIssueTypeSchemeResourceConfig(testAttributeNames[0]),
+				Config: testAccJiraIssueTypeSchemeResourceConfig(randomName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "name", testAttributeNames[0]),
+					resource.TestCheckResourceAttr(resourceName, "name", randomName),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "issue_type_ids.#", "1"),
 				),
@@ -33,9 +33,9 @@ func TestAccJiraIssueTypeSchemeResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccJiraIssueTypeSchemeResourceConfig(testAttributeNames[1]),
+				Config: testAccJiraIssueTypeSchemeResourceConfig(randomName + "B"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", testAttributeNames[1]),
+					resource.TestCheckResourceAttr(resourceName, "name", randomName+"B"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase

--- a/internal/provider/resource_jira_issue_type_test.go
+++ b/internal/provider/resource_jira_issue_type_test.go
@@ -4,23 +4,23 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccJiraIssueTypeResource(t *testing.T) {
+	randomName := acctest.RandomWithPrefix("tf-test-issue-type")
 	resourceName := "atlassian_jira_issue_type.test"
-	testAtrributeNames := []string{"Test Jira Issue Type 1", "Test Jira Issue Type 2"}
-
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccJiraIssueTypeResourceConfig(testAtrributeNames[0]),
+				Config: testAccJiraIssueTypeResourceConfig(randomName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "name", testAtrributeNames[0]),
+					resource.TestCheckResourceAttr(resourceName, "name", randomName),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "type", "standard"),
 					resource.TestCheckResourceAttr(resourceName, "hierarchy_level", "0"),
@@ -35,9 +35,9 @@ func TestAccJiraIssueTypeResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccJiraIssueTypeResourceConfig(testAtrributeNames[1]),
+				Config: testAccJiraIssueTypeResourceConfig(randomName + "B"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", testAtrributeNames[1]),
+					resource.TestCheckResourceAttr(resourceName, "name", randomName+"B"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase


### PR DESCRIPTION
Closes #98 

```
TF_ACC=1 go test -v -cover -timeout 120m ./... -run TestAccJiraIssueTypeResource
?   	github.com/openscientia/terraform-provider-atlassian	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/issuelabels	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/prlabels	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/repolabels	[no test files]
=== RUN   TestAccJiraIssueTypeResource
=== PAUSE TestAccJiraIssueTypeResource
=== CONT  TestAccJiraIssueTypeResource
--- PASS: TestAccJiraIssueTypeResource (2.81s)
PASS
coverage: 10.1% of statements
ok  	github.com/openscientia/terraform-provider-atlassian/internal/provider	3.039s	coverage: 10.1% of statements
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_plan_modification	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_validation	[no test files]
```

```
TF_ACC=1 go test -v -cover -timeout 120m ./... -run TestAccJiraIssueTypeSchemeResource
?   	github.com/openscientia/terraform-provider-atlassian	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/issuelabels	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/prlabels	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/repolabels	[no test files]
=== RUN   TestAccJiraIssueTypeSchemeResource
=== PAUSE TestAccJiraIssueTypeSchemeResource
=== CONT  TestAccJiraIssueTypeSchemeResource
--- PASS: TestAccJiraIssueTypeSchemeResource (3.52s)
PASS
coverage: 15.6% of statements
ok  	github.com/openscientia/terraform-provider-atlassian/internal/provider	3.873s	coverage: 15.6% of statements
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_plan_modification	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_validation	[no test files]
```