### PR TITLE
feat: enhance logging output to improve overall provider debugging

### DIFF
--- a/.changelog/101.txt
+++ b/.changelog/101.txt
@@ -1,5 +1,5 @@
 ```release-note:note
-resource/atlassian_jira_issue_type: Enhance logging ouput to improve provider debugging
+resource/atlassian_jira_issue_type: Enhance logging output to improve provider debugging
 ```
 
 ```release-note:note

--- a/.changelog/101.txt
+++ b/.changelog/101.txt
@@ -1,0 +1,7 @@
+```release-note:note
+resource/atlassian_jira_issue_type: Enhance logging ouput to improve provider debugging
+```
+
+```release-note:note
+resource/atlassian_jira_issue_type_scheme: Enhance logging output to improve provider debugging
+```

--- a/internal/provider/resource_jira_issue_type_scheme.go
+++ b/internal/provider/resource_jira_issue_type_scheme.go
@@ -89,6 +89,8 @@ func (r jiraIssueTypeSchemeResource) ImportState(ctx context.Context, req resour
 }
 
 func (r jiraIssueTypeSchemeResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	tflog.Debug(ctx, "Creating issue type scheme resource")
+
 	if !r.p.configured {
 		resp.Diagnostics.AddError(
 			"Provider not configured",
@@ -98,11 +100,13 @@ func (r jiraIssueTypeSchemeResource) Create(ctx context.Context, req resource.Cr
 	}
 
 	var plan jiraIssueTypeSchemeResourceData
-	diags := req.Plan.Get(ctx, &plan)
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	tflog.Debug(ctx, "Loaded issue type scheme plan", map[string]interface{}{
+		"createPlan": fmt.Sprintf("%+v", plan),
+	})
 
 	if plan.Description.Unknown {
 		plan.Description = types.String{Value: ""}
@@ -129,54 +133,54 @@ func (r jiraIssueTypeSchemeResource) Create(ctx context.Context, req resource.Cr
 	issueTypeSchemePayload.Name = plan.Name.Value
 	issueTypeSchemePayload.Description = plan.Description.Value
 	issueTypeSchemePayload.DefaultIssueTypeID = plan.DefaultIssueTypeId.Value
-	diags = plan.IssueTypeIds.ElementsAs(ctx, &issueTypeSchemePayload.IssueTypeIds, false)
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(plan.IssueTypeIds.ElementsAs(ctx, &issueTypeSchemePayload.IssueTypeIds, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	returnedIssueTypeScheme, res, err := r.p.jira.Issue.Type.Scheme.Create(ctx, issueTypeSchemePayload)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create issue type scheme, got error: %s\n%s", err.Error(), res.Bytes.String()))
+		var resBody string
+		if res != nil {
+			resBody = res.Bytes.String()
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create issue type scheme, got error: %s\n%s", err, resBody))
 		return
 	}
+	tflog.Debug(ctx, "Created issue type scheme")
 
-	// Store new issue type scheme ID in state
 	plan.ID = types.String{Value: returnedIssueTypeScheme.IssueTypeSchemeID}
 
-	tflog.Debug(ctx, "created an issue type scheme", map[string]interface{}{
-		"issue_type_scheme_id": returnedIssueTypeScheme.IssueTypeSchemeID,
+	tflog.Debug(ctx, "Storing issue type scheme into the state", map[string]interface{}{
+		"createNewState": fmt.Sprintf("%+v", plan),
 	})
-
-	diags = resp.State.Set(ctx, &plan)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
 func (r jiraIssueTypeSchemeResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	tflog.Debug(ctx, "Reading issue type scheme resource")
+
 	var state jiraIssueTypeSchemeResourceData
-	diags := req.State.Get(ctx, &state)
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	tflog.Debug(ctx, "Loaded issue type scheme from state", map[string]interface{}{
+		"readState": fmt.Sprintf("%+v", state),
+	})
 
-	issueTypeSchemeID, err := strconv.Atoi(state.ID.Value)
-	if err != nil {
-		resp.Diagnostics.AddError("Provider Error", fmt.Sprintf("Conversion failed: %s", err.Error()))
-		return
-	}
+	issueTypeSchemeID, _ := strconv.Atoi(state.ID.Value)
 
-	// Get issue type scheme details
 	returnedIssueTypeScheme, res, err := r.p.jira.Issue.Type.Scheme.Gets(ctx, []int{issueTypeSchemeID}, 0, 50)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read issue type scheme, got error: %s\n%s", err.Error(), res.Bytes.String()))
+		var resBody string
+		if res != nil {
+			resBody = res.Bytes.String()
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read issue type scheme, got error: %s\n%s", err, resBody))
 		return
 	}
 
-	// Get issue type scheme items
 	returnedIssueTypeSchemeItems, res, err := r.p.jira.Issue.Type.Scheme.Items(ctx, []int{issueTypeSchemeID}, 0, 50)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get issue type scheme items, got error: %s\n%s", err.Error(), res.Bytes.String()))
@@ -189,33 +193,40 @@ func (r jiraIssueTypeSchemeResource) Read(ctx context.Context, req resource.Read
 		av := types.String{Value: elem.IssueTypeID}
 		ids.Elems = append(ids.Elems, av)
 	}
+	tflog.Debug(ctx, "Retrieved issue type scheme from API state")
 
 	state.Name = types.String{Value: returnedIssueTypeScheme.Values[0].Name}
 	state.Description = types.String{Value: returnedIssueTypeScheme.Values[0].Description}
 	state.DefaultIssueTypeId = types.String{Value: returnedIssueTypeScheme.Values[0].DefaultIssueTypeID}
 	state.IssueTypeIds = ids
 
-	diags = resp.State.Set(ctx, &state)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
+	tflog.Debug(ctx, "Storing issue type scheme into the state", map[string]interface{}{
+		"readNewState": fmt.Sprintf("%+v", state),
+	})
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
 func (r jiraIssueTypeSchemeResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	tflog.Debug(ctx, "Updating issue type scheme resource")
+
 	var plan jiraIssueTypeSchemeResourceData
-	diags := req.Plan.Get(ctx, &plan)
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	tflog.Debug(ctx, "Loaded issue type scheme plan", map[string]interface{}{
+		"updatePlan": fmt.Sprintf("%+v", plan),
+	})
 
 	var state jiraIssueTypeSchemeResourceData
-	diags = req.State.Get(ctx, &state)
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	tflog.Debug(ctx, "Loaded issue type scheme from state", map[string]interface{}{
+		"updateState": fmt.Sprintf("%+v", state),
+	})
+
 	issueTypeSchemeID, _ := strconv.Atoi(state.ID.Value)
 
 	issueTypeSchemePayload := new(models.IssueTypeSchemePayloadScheme)
@@ -224,7 +235,11 @@ func (r jiraIssueTypeSchemeResource) Update(ctx context.Context, req resource.Up
 
 	res, err := r.p.jira.Issue.Type.Scheme.Update(ctx, issueTypeSchemeID, issueTypeSchemePayload)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update issue type scheme, got error: %s\n%s", err.Error(), res.Bytes.String()))
+		var resBody string
+		if res != nil {
+			resBody = res.Bytes.String()
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update issue type scheme, got error: %s\n%s", err, resBody))
 		return
 	}
 
@@ -262,10 +277,15 @@ func (r jiraIssueTypeSchemeResource) Update(ctx context.Context, req resource.Up
 	if len(ids) != 0 {
 		res, err = r.p.jira.Issue.Type.Scheme.Append(ctx, issueTypeSchemeID, ids)
 		if err != nil {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to add issue types to issue type scheme, got error: %s\n%s", err.Error(), res.Bytes.String()))
+			var resBody string
+			if res != nil {
+				resBody = res.Bytes.String()
+			}
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to add issue types to issue type scheme, got error: %s\n%s", err, resBody))
 			return
 		}
 	}
+	tflog.Debug(ctx, "Updated issue type scheme in API state")
 
 	var result = jiraIssueTypeSchemeResourceData{
 		ID:                 types.String{Value: state.ID.Value},
@@ -275,33 +295,34 @@ func (r jiraIssueTypeSchemeResource) Update(ctx context.Context, req resource.Up
 		IssueTypeIds:       plan.IssueTypeIds,
 	}
 
-	diags = resp.State.Set(ctx, &result)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
+	tflog.Debug(ctx, "Storing issue type scheme into the state", map[string]interface{}{
+		"updateNewState": fmt.Sprintf("%+v", result),
+	})
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
 }
 
 func (r jiraIssueTypeSchemeResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	tflog.Debug(ctx, "Deleting issue type scheme resource")
+
 	var state jiraIssueTypeSchemeResourceData
-	diags := req.State.Get(ctx, &state)
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	tflog.Debug(ctx, "Loaded issue type scheme from state")
 
-	issueTypeSchemeID, err := strconv.Atoi(state.ID.Value)
-	if err != nil {
-		resp.Diagnostics.AddError("Provider Error", fmt.Sprintf("Unable to convert issue type scheme ID, got error: %s", err.Error()))
-		return
-	}
+	issueTypeSchemeID, _ := strconv.Atoi(state.ID.Value)
 
 	res, err := r.p.jira.Issue.Type.Scheme.Delete(ctx, issueTypeSchemeID)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete issue type scheme, got error: %s\n%s", err, res.Bytes.String()))
+		var resBody string
+		if res != nil {
+			resBody = res.Bytes.String()
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete issue type scheme, got error: %s\n%s", err, resBody))
 		return
 	}
+	tflog.Debug(ctx, "Deleted issue type scheme from API state")
 
-	// Remove resource from state
-	resp.State.RemoveResource(ctx)
+	// If a Resource type Delete method is completed without error, the framework will automatically remove the resource.
 }


### PR DESCRIPTION
Closes #101 

```
TF_ACC=1 go test -v -cover -timeout 120m ./... -run TestAccJiraIssueTypeResource
?   	github.com/openscientia/terraform-provider-atlassian	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/issuelabels	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/prlabels	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/repolabels	[no test files]
=== RUN   TestAccJiraIssueTypeResource
=== PAUSE TestAccJiraIssueTypeResource
=== CONT  TestAccJiraIssueTypeResource
--- PASS: TestAccJiraIssueTypeResource (2.65s)
PASS
coverage: 10.3% of statements
ok  	github.com/openscientia/terraform-provider-atlassian/internal/provider	3.036s	coverage: 10.3% of statements
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_plan_modification	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_validation	[no test files]
```

```
TF_ACC=1 go test -v -cover -timeout 120m ./... -run TestAccJiraIssueTypeSchemeResource
?   	github.com/openscientia/terraform-provider-atlassian	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/issuelabels	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/prlabels	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/generate/repolabels	[no test files]
=== RUN   TestAccJiraIssueTypeSchemeResource
=== PAUSE TestAccJiraIssueTypeSchemeResource
=== CONT  TestAccJiraIssueTypeSchemeResource
--- PASS: TestAccJiraIssueTypeSchemeResource (3.63s)
PASS
coverage: 15.6% of statements
ok  	github.com/openscientia/terraform-provider-atlassian/internal/provider	3.998s	coverage: 15.6% of statements
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_plan_modification	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_validation	[no test files]
```