### PR TITLE
chore(GNUmakefile): refactor; enable parameters in make testacc

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,12 +1,17 @@
-TEST?=$$(go list ./... | grep -v 'vendor')
+PKG 				 = internal/provider/...
+ACCTEST_COUNT		?= 1
+ACCTEST_TIMEOUT     ?= 180m
+ACCTEST_PARALLELISM ?= 20
 
-default: install
+ifneq ($(origin TESTS), undefined)
+	RUNARGS = -run='$(TESTS)'
+endif
 
+default: build
+
+# See https://go.dev/ref/mod#go-install
 build:
-	go build -v ./...
-
-install: build
-	go install -v ./...
+	go install -v
 
 # See https://golangci-lint.run/
 lint: 
@@ -16,14 +21,23 @@ lint:
 tfdocs:
 	tfplugindocs generate
 
+# See https://go.dev/blog/generate
 gen:
 	rm -f .github/labeler-issue-labels.yml
 	rm -f .github/labeler-pr-labels.yml
 	rm -f infrastructure/repository/labels-resource.tf
 	go generate ./...
 
-test:
-	go test -v -cover -timeout=120s -parallel=4 ./...
-
+# See https://pkg.go.dev/cmd/go/internal/test
 testacc:
-	TF_ACC=1 go test -v -cover -timeout 120m ./...
+	@if [ "$(TESTARGS)" = "-run=TestAccXXX" ]; then \
+		echo ""; \
+		echo "Error: Skipping example acceptance testing pattern. Update TESTS for the relevant *_test.go file."; \
+		echo ""; \
+		echo "For example if testing internal/provider/resource_jira_issue_type.go, use the test names in internal/provider/resource_jira_issue_type_test.go starting with TestAcc and up to the underscore:"; \
+		echo "make testacc TESTS=TestAccJiraIssueType_"; \
+		echo ""; \
+		echo "See the contributing guide for more information: https://github.com/openscientia/terraform-provider-atlassian/blob/main/.github/contributing/acceptance-tests.md"; \
+		exit 1; \
+	fi
+	TF_ACC=1 go test ./$(PKG) -v -count $(ACCTEST_COUNT) -parallel $(ACCTEST_PARALLELISM) $(RUNARGS) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT)


### PR DESCRIPTION
Closes #110 

```console
make testacc TESTS=TestAccJiraIssueType_
TF_ACC=1 go test ./internal/provider/... -v -count 1 -parallel 20 -run='TestAccJiraIssueType_'  -timeout 180m
=== RUN   TestAccJiraIssueType_Basic
=== PAUSE TestAccJiraIssueType_Basic
=== RUN   TestAccJiraIssueType_Name
=== PAUSE TestAccJiraIssueType_Name
=== RUN   TestAccJiraIssueType_Description
=== PAUSE TestAccJiraIssueType_Description
=== RUN   TestAccJiraIssueType_Type
=== PAUSE TestAccJiraIssueType_Type
=== RUN   TestAccJiraIssueType_HierarchyLevel
=== PAUSE TestAccJiraIssueType_HierarchyLevel
=== RUN   TestAccJiraIssueType_AvatarId
=== PAUSE TestAccJiraIssueType_AvatarId
=== CONT  TestAccJiraIssueType_Basic
=== CONT  TestAccJiraIssueType_AvatarId
=== CONT  TestAccJiraIssueType_Type
=== CONT  TestAccJiraIssueType_Description
=== CONT  TestAccJiraIssueType_Name
=== CONT  TestAccJiraIssueType_HierarchyLevel
--- PASS: TestAccJiraIssueType_Basic (1.67s)
--- PASS: TestAccJiraIssueType_Type (2.57s)
--- PASS: TestAccJiraIssueType_Name (2.57s)
--- PASS: TestAccJiraIssueType_Description (2.59s)
--- PASS: TestAccJiraIssueType_HierarchyLevel (2.91s)
--- PASS: TestAccJiraIssueType_AvatarId (3.14s)
PASS
ok  	github.com/openscientia/terraform-provider-atlassian/internal/provider	3.386s
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_plan_modification	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_validation	[no test files]
```