### PR TITLE
fix: resolve golangci-lint errors in `go-atlassian` v1.4.4

### DIFF
--- a/internal/provider/resource_jira_issue_type_screen_scheme_test.go
+++ b/internal/provider/resource_jira_issue_type_screen_scheme_test.go
@@ -94,22 +94,22 @@ func TestAccJiraIssueTypeScreenScheme_IssueTypeMappings(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIssueTypeScreenSchemeConfig_issuetypemappings(resourceName, randomName, "10000"),
+				Config: testAccIssueTypeScreenSchemeConfig_issuetypemappings(resourceName, randomName, "foo"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "issue_type_mappings.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "issue_type_mappings.0.issue_type_id", "default"),
 					resource.TestCheckResourceAttr(resourceName, "issue_type_mappings.0.screen_scheme_id", "1"),
-					resource.TestCheckResourceAttr(resourceName, "issue_type_mappings.1.issue_type_id", "10000"),
+					resource.TestCheckResourceAttrPair(resourceName, "issue_type_mappings.1.issue_type_id", "atlassian_jira_issue_type.foo", "id"),
 					resource.TestCheckResourceAttr(resourceName, "issue_type_mappings.1.screen_scheme_id", "1"),
 				),
 			},
 			{
-				Config: testAccIssueTypeScreenSchemeConfig_issuetypemappings(resourceName, randomName, "10001"),
+				Config: testAccIssueTypeScreenSchemeConfig_issuetypemappings(resourceName, randomName, "bar"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "issue_type_mappings.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "issue_type_mappings.0.issue_type_id", "default"),
 					resource.TestCheckResourceAttr(resourceName, "issue_type_mappings.0.screen_scheme_id", "1"),
-					resource.TestCheckResourceAttr(resourceName, "issue_type_mappings.1.issue_type_id", "10001"),
+					resource.TestCheckResourceAttrPair(resourceName, "issue_type_mappings.1.issue_type_id", "atlassian_jira_issue_type.bar", "id"),
 					resource.TestCheckResourceAttr(resourceName, "issue_type_mappings.1.screen_scheme_id", "1"),
 				),
 			},
@@ -185,9 +185,17 @@ func testAccIssueTypeScreenSchemeConfig_defaultmapping(resourceName, name string
 	}
 }
 
-func testAccIssueTypeScreenSchemeConfig_issuetypemappings(resourceName, name, nonDefaultIssueTypeId string) string {
+func testAccIssueTypeScreenSchemeConfig_issuetypemappings(resourceName, name, nonDefaultIssueTypeSuffix string) string {
 	splits := strings.Split(resourceName, ".")
 	return fmt.Sprintf(`
+	resource "atlassian_jira_issue_type" "foo" {
+		name = "%[3]s-foo"
+	}
+
+	resource "atlassian_jira_issue_type" "bar" {
+		name = "%[3]s-bar"
+	}
+
 	resource %[1]q %[2]q {
 		name = %[3]q
 		issue_type_mappings = [
@@ -196,10 +204,10 @@ func testAccIssueTypeScreenSchemeConfig_issuetypemappings(resourceName, name, no
 				screen_scheme_id = "1"
 			},
 			{
-				issue_type_id = %[4]q 
+				issue_type_id = atlassian_jira_issue_type.%[4]s.id  
 				screen_scheme_id = "1" 
 			}
 		]
 	}
-	`, splits[0], splits[1], name, nonDefaultIssueTypeId)
+	`, splits[0], splits[1], name, nonDefaultIssueTypeSuffix)
 }


### PR DESCRIPTION
Re-run of acceptance tests of affected resources:

```console
make testacc TESTS=TestAccJiraScreenScheme
TF_ACC=1 go test ./internal/provider/... -v -count 1 -parallel 20 -run='TestAccJiraScreenScheme'  -timeout 180m
=== RUN   TestAccJiraScreenSchemeDataSource_Basic
=== PAUSE TestAccJiraScreenSchemeDataSource_Basic
=== RUN   TestAccJiraScreenScheme_Basic
=== PAUSE TestAccJiraScreenScheme_Basic
=== RUN   TestAccJiraScreenScheme_Description
=== PAUSE TestAccJiraScreenScheme_Description
=== RUN   TestAccJiraScreenScheme_Screens
=== PAUSE TestAccJiraScreenScheme_Screens
=== CONT  TestAccJiraScreenSchemeDataSource_Basic
=== CONT  TestAccJiraScreenScheme_Description
=== CONT  TestAccJiraScreenScheme_Screens
=== CONT  TestAccJiraScreenScheme_Basic
--- PASS: TestAccJiraScreenScheme_Basic (1.64s)
--- PASS: TestAccJiraScreenSchemeDataSource_Basic (1.77s)
--- PASS: TestAccJiraScreenScheme_Screens (2.04s)
--- PASS: TestAccJiraScreenScheme_Description (2.05s)
PASS
ok  	github.com/openscientia/terraform-provider-atlassian/internal/provider	2.565s
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_plan_modification	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_validation	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/models	[no test files]
```

```console
make testacc TESTS=TestAccJiraIssueTypeScreenScheme
TF_ACC=1 go test ./internal/provider/... -v -count 1 -parallel 20 -run='TestAccJiraIssueTypeScreenScheme'  -timeout 180m
=== RUN   TestAccJiraIssueTypeScreenSchemeDataSource_Basic
=== PAUSE TestAccJiraIssueTypeScreenSchemeDataSource_Basic
=== RUN   TestAccJiraIssueTypeScreenScheme_Basic
=== PAUSE TestAccJiraIssueTypeScreenScheme_Basic
=== RUN   TestAccJiraIssueTypeScreenScheme_Description
=== PAUSE TestAccJiraIssueTypeScreenScheme_Description
=== RUN   TestAccJiraIssueTypeScreenScheme_DefaultMapping
=== PAUSE TestAccJiraIssueTypeScreenScheme_DefaultMapping
=== RUN   TestAccJiraIssueTypeScreenScheme_IssueTypeMappings
=== PAUSE TestAccJiraIssueTypeScreenScheme_IssueTypeMappings
=== CONT  TestAccJiraIssueTypeScreenSchemeDataSource_Basic
=== CONT  TestAccJiraIssueTypeScreenScheme_DefaultMapping
=== CONT  TestAccJiraIssueTypeScreenScheme_IssueTypeMappings
=== CONT  TestAccJiraIssueTypeScreenScheme_Description
=== CONT  TestAccJiraIssueTypeScreenScheme_Basic
--- PASS: TestAccJiraIssueTypeScreenScheme_Basic (1.46s)
--- PASS: TestAccJiraIssueTypeScreenSchemeDataSource_Basic (1.92s)
--- PASS: TestAccJiraIssueTypeScreenScheme_Description (2.02s)
--- PASS: TestAccJiraIssueTypeScreenScheme_DefaultMapping (2.42s)
--- PASS: TestAccJiraIssueTypeScreenScheme_IssueTypeMappings (3.05s)
PASS
ok  	github.com/openscientia/terraform-provider-atlassian/internal/provider	3.245s
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_plan_modification	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/attribute_validation	[no test files]
?   	github.com/openscientia/terraform-provider-atlassian/internal/provider/models	[no test files]
```