### PR TITLE
fix: remove reference to deprecated provider interface

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -29,8 +29,7 @@ type (
 )
 
 var (
-	_ provider.Provider             = (*atlassianProvider)(nil)
-	_ provider.ProviderWithMetadata = (*atlassianProvider)(nil)
+	_ provider.Provider = (*atlassianProvider)(nil)
 )
 
 func New(version string) func() provider.Provider {


### PR DESCRIPTION
```console
golangci-lint run -v
INFO [config_reader] Config search paths: [./ /Users/iacb/dev/terraform-provider-atlassian /Users/iacb/dev /Users/iacb /Users /]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 17 linters: [durationcheck errcheck exportloopref gofmt gosimple govet ineffassign makezero misspell nilerr predeclared staticcheck tenv typecheck unconvert unparam unused]
INFO [loader] Go packages loading at mode 575 (imports|name|compiled_files|deps|exports_file|files|types_sizes) took 192.993042ms
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 6.659625ms
INFO [linters_context/goanalysis] analyzers took 0s with no stages
INFO [runner] processing took 2.497µs with stages: max_same_issues: 708ns, cgo: 250ns, skip_dirs: 250ns, max_from_linter: 208ns, autogenerated_exclude: 166ns, nolint: 166ns, skip_files: 166ns, uniq_by_line: 125ns, filename_unadjuster: 125ns, diff: 42ns, max_per_file_from_linter: 42ns, sort_results: 42ns, severity-rules: 42ns, path_prefixer: 42ns, path_shortener: 41ns, source_code: 41ns, identifier_marker: 41ns, exclude: 0s, path_prettifier: 0s, exclude-rules: 0s
INFO [runner] linters took 69.528667ms with stages: goanalysis_metalinter: 69.489875ms
INFO File cache stats: 0 entries of total size 0B
INFO Memory: 4 samples, avg is 40.8MB, max is 73.4MB
INFO Execution took 275.516167ms
```